### PR TITLE
PR HAPI-107 first version of CSV support

### DIFF
--- a/hdx_hapi/endpoints/get_admin_level.py
+++ b/hdx_hapi/endpoints/get_admin_level.py
@@ -7,9 +7,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from hdx_hapi.endpoints.models.admin1_view import Admin1ViewPydantic
 from hdx_hapi.endpoints.models.admin2_view import Admin2ViewPydantic
 from hdx_hapi.endpoints.models.location_view import LocationViewPydantic
-from hdx_hapi.endpoints.util.util import pagination_parameters
+from hdx_hapi.endpoints.util.util import OutputFormat, pagination_parameters
 from hdx_hapi.services.admin1_logic import get_admin1_srv
 from hdx_hapi.services.admin2_logic import get_admin2_srv
+from hdx_hapi.services.csv_transform_logic import transform_result_to_csv_stream_if_requested
 from hdx_hapi.services.location_logic import get_locations_srv
 from hdx_hapi.services.sql_alchemy_session import get_db
 
@@ -27,6 +28,8 @@ async def get_locations(
     name: Annotated[str, Query(max_length=10, description='Location name')] = None,
     reference_period_start: Annotated[datetime | date, Query(description='Start date of reference period', example='2022-01-01T00:00:00')] = None,
     reference_period_end: Annotated[datetime | date, Query(description='End date of reference period', example='2023-01-01T23:59:59')] = None,
+
+    output_format: OutputFormat = OutputFormat.JSON,
 ):
     """Get the list of locations.
     """    
@@ -38,7 +41,7 @@ async def get_locations(
         reference_period_start=reference_period_start,
         reference_period_end=reference_period_end,
     )
-    return result
+    return transform_result_to_csv_stream_if_requested(result, output_format, LocationViewPydantic)
 
 
 @router.get('/api/admin1', response_model=List[Admin1ViewPydantic])
@@ -50,6 +53,8 @@ async def get_admin1(
     is_unspecified: Annotated[bool, Query(description='Is specified or not')] = None,
     reference_period_start: Annotated[datetime | date, Query(description='Start date of reference period', example='2022-01-01T00:00:00')] = None,
     reference_period_end: Annotated[datetime | date, Query(description='End date of reference period', example='2023-01-01T23:59:59')] = None,
+
+    output_format: OutputFormat = OutputFormat.JSON,
 ):
     """Get the list of admin1 entries.
     """    
@@ -62,7 +67,7 @@ async def get_admin1(
         reference_period_start=reference_period_start,
         reference_period_end=reference_period_end,
     )
-    return result
+    return transform_result_to_csv_stream_if_requested(result, output_format, Admin1ViewPydantic)
 
 
 @router.get('/api/admin2', response_model=List[Admin2ViewPydantic])
@@ -74,6 +79,8 @@ async def get_admin2(
     is_unspecified: Annotated[bool, Query(description='Is specified or not')] = None,
     reference_period_start: Annotated[datetime | date, Query(description='Start date of reference period', example='2022-01-01T00:00:00')] = None,
     reference_period_end: Annotated[datetime | date, Query(description='End date of reference period', example='2023-01-01T23:59:59')] = None,
+
+    output_format: OutputFormat = OutputFormat.JSON,
 ):
     """Get the list of admin2 entries.
     """    
@@ -86,4 +93,4 @@ async def get_admin2(
         reference_period_start=reference_period_start,
         reference_period_end=reference_period_end,
     )
-    return result
+    return transform_result_to_csv_stream_if_requested(result, output_format, Admin2ViewPydantic)

--- a/hdx_hapi/endpoints/get_demographic.py
+++ b/hdx_hapi/endpoints/get_demographic.py
@@ -6,14 +6,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from hdx_hapi.endpoints.models.age_range_view import AgeRangeViewPydantic
 from hdx_hapi.endpoints.models.gender_view import GenderViewPydantic
-from hdx_hapi.endpoints.util.util import pagination_parameters
+from hdx_hapi.endpoints.util.util import pagination_parameters, OutputFormat
 from hdx_hapi.services.age_range_logic import get_age_ranges_srv
+from hdx_hapi.services.csv_transform_logic import transform_result_to_csv_stream_if_requested
 from hdx_hapi.services.gender_logic import get_genders_srv
 from hdx_hapi.services.sql_alchemy_session import get_db
+
 
 router = APIRouter(
     tags=['demographic'],
 )
+
 
 @router.get('/api/age_range', response_model=List[AgeRangeViewPydantic])
 async def get_age_ranges(
@@ -21,7 +24,9 @@ async def get_age_ranges(
     db: AsyncSession = Depends(get_db),
     code: Annotated[str, Query(max_length=32, description='Age range code', example='20-24')] = None,
     age_min: Annotated[int, Query(ge=0, description='Minimum age', example=10)] = None,
-    age_max: Annotated[int, Query(ge=0, description='Maximum age', example=50)] = None
+    age_max: Annotated[int, Query(ge=0, description='Maximum age', example=50)] = None,
+
+    output_format: OutputFormat = OutputFormat.JSON,
 ):
     """Get the list of all active age ranges.
     """    
@@ -32,7 +37,8 @@ async def get_age_ranges(
         age_min=age_min,
         age_max=age_max
     )
-    return result
+    
+    return transform_result_to_csv_stream_if_requested(result, output_format, AgeRangeViewPydantic)
 
 
 @router.get('/api/gender', response_model=List[GenderViewPydantic])
@@ -40,7 +46,9 @@ async def get_genders(
     pagination_parameters: Annotated[dict, Depends(pagination_parameters)],
     db: AsyncSession = Depends(get_db),
     code: Annotated[str, Query(max_length=1, description='Gender code', example='m')] = None,
-    description: Annotated[str, Query(max_length=50, description='Gender description', example='female')] = None
+    description: Annotated[str, Query(max_length=50, description='Gender description', example='female')] = None,
+
+    output_format: OutputFormat = OutputFormat.JSON,
 ):
     """Get the list of all genders.
     """    
@@ -50,4 +58,4 @@ async def get_genders(
         code=code,
         description=description
     )
-    return result
+    return transform_result_to_csv_stream_if_requested(result, output_format, GenderViewPydantic)

--- a/hdx_hapi/endpoints/get_hdx_metadata.py
+++ b/hdx_hapi/endpoints/get_hdx_metadata.py
@@ -1,5 +1,5 @@
 from datetime import datetime, date
-from typing import List, Annotated, Dict
+from typing import List, Annotated
 from fastapi import Depends, Query, APIRouter
 
 
@@ -7,7 +7,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from hdx_hapi.endpoints.models.dataset_view import DatasetViewPydantic
 from hdx_hapi.endpoints.models.resource_view import ResourceViewPydantic
-from hdx_hapi.endpoints.util.util import pagination_parameters
+from hdx_hapi.endpoints.util.util import OutputFormat, pagination_parameters
+from hdx_hapi.services.csv_transform_logic import transform_result_to_csv_stream_if_requested
 from hdx_hapi.services.dataset_logic import get_datasets_srv
 from hdx_hapi.services.resource_logic import get_resources_srv
 from hdx_hapi.services.sql_alchemy_session import get_db
@@ -26,6 +27,8 @@ async def get_datasets(
     title: Annotated[str, Query(max_length=128, description='HDX Dataset title or display name')] = None,
     provider_code: Annotated[str, Query(max_length=10, description='Dataset ID given by provider')] = None,
     provider_name: Annotated[str, Query(max_length=128, description='Dataset name given by provider')] = None,
+
+    output_format: OutputFormat = OutputFormat.JSON,
 ):
     """
     Return the list of datasets
@@ -39,7 +42,7 @@ async def get_datasets(
         provider_code=provider_code,
         provider_name=provider_name,
     )
-    return result
+    return transform_result_to_csv_stream_if_requested(result, output_format, DatasetViewPydantic)
 
 
 @router.get('/api/resource', response_model=List[ResourceViewPydantic])
@@ -56,6 +59,8 @@ async def get_resources(
     dataset_title: Annotated[str, Query(max_length=10, description='HDX Dataset title')] = None,
     dataset_provider_code: Annotated[str, Query(max_length=10, description='Dataset ID given by provider')] = None,
     dataset_provider_name: Annotated[str, Query(max_length=10, description='Dataset name given by provider')] = None,
+
+    output_format: OutputFormat = OutputFormat.JSON,
 ):
     """
     Return the list of datasets
@@ -74,4 +79,4 @@ async def get_resources(
         dataset_provider_code=dataset_provider_code,
         dataset_provider_name=dataset_provider_name,
     )
-    return result
+    return transform_result_to_csv_stream_if_requested(result, output_format, ResourceViewPydantic)

--- a/hdx_hapi/endpoints/get_humanitarian_response.py
+++ b/hdx_hapi/endpoints/get_humanitarian_response.py
@@ -1,4 +1,4 @@
-from typing import List, Annotated, Dict
+from typing import List, Annotated
 from fastapi import Depends, Query, APIRouter
 
 
@@ -7,7 +7,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from hdx_hapi.endpoints.models.org_view import OrgViewPydantic
 from hdx_hapi.endpoints.models.org_type_view import OrgTypeViewPydantic
 from hdx_hapi.endpoints.models.sector_view import SectorViewPydantic
-from hdx_hapi.endpoints.util.util import pagination_parameters
+from hdx_hapi.endpoints.util.util import OutputFormat, pagination_parameters
+from hdx_hapi.services.csv_transform_logic import transform_result_to_csv_stream_if_requested
 from hdx_hapi.services.org_logic import get_orgs_srv
 from hdx_hapi.services.org_type_logic import get_org_types_srv
 from hdx_hapi.services.sector_logic import get_sectors_srv
@@ -27,6 +28,8 @@ async def get_orgs(
     name: Annotated[str, Query(max_length=10, description='Organization name', example='Humanitarian Data Exchange')] = None,
     reference_period_start: Annotated[datetime | date, Query(description='Start date of reference period', example='2022-01-01T00:00:00')] = None,
     reference_period_end: Annotated[datetime | date, Query(description='End date of reference period', example='2023-01-01T23:59:59')] = None,
+
+    output_format: OutputFormat = OutputFormat.JSON,
 ):
     """Get the list of all active organisations.
     """    
@@ -38,14 +41,16 @@ async def get_orgs(
         reference_period_start=reference_period_start,
         reference_period_end=reference_period_end,
     )
-    return result
+    return transform_result_to_csv_stream_if_requested(result, output_format, OrgViewPydantic)
 
 @router.get('/api/org_type', response_model=List[OrgTypeViewPydantic])
 async def get_org_types(
     pagination_parameters: Annotated[dict, Depends(pagination_parameters)],
     db: AsyncSession = Depends(get_db),
     code: Annotated[str, Query(max_length=32, description='Organization type code', example='123')] = None,
-    description: Annotated[str, Query(max_length=50, description='Organization type description', example='Government')] = None
+    description: Annotated[str, Query(max_length=50, description='Organization type description', example='Government')] = None,
+
+    output_format: OutputFormat = OutputFormat.JSON,
 ):
     """Get the list of all active organisation types.
     """    
@@ -55,7 +60,7 @@ async def get_org_types(
         code=code,
         description=description
     )
-    return result
+    return transform_result_to_csv_stream_if_requested(result, output_format, OrgTypeViewPydantic)
 
 @router.get('/api/sector', response_model=List[SectorViewPydantic])
 async def get_sectors(
@@ -65,6 +70,8 @@ async def get_sectors(
     name: Annotated[str, Query(max_length=50, description='Sector name', example='Health')] = None,
     reference_period_start: Annotated[datetime | date, Query(description='Start date of reference period', example='2022-01-01T00:00:00')] = None,
     reference_period_end: Annotated[datetime | date, Query(description='End date of reference period', example='2023-01-01T23:59:59')] = None,
+
+    output_format: OutputFormat = OutputFormat.JSON,
 ):
     """Get the list of all active sectors.
     """    
@@ -76,4 +83,4 @@ async def get_sectors(
         reference_period_start=reference_period_start,
         reference_period_end=reference_period_end,
     )
-    return result
+    return transform_result_to_csv_stream_if_requested(result, output_format, SectorViewPydantic)

--- a/hdx_hapi/endpoints/get_operational_presence.py
+++ b/hdx_hapi/endpoints/get_operational_presence.py
@@ -1,12 +1,13 @@
 from datetime import datetime, date
-from typing import List, Annotated, Dict
+from typing import List, Annotated
 from fastapi import Depends, Query, APIRouter
 
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from hdx_hapi.endpoints.models.operational_presence_view import OperationalPresenceViewPydantic
-from hdx_hapi.endpoints.util.util import pagination_parameters
+from hdx_hapi.endpoints.util.util import OutputFormat, pagination_parameters
+from hdx_hapi.services.csv_transform_logic import transform_result_to_csv_stream_if_requested
 from hdx_hapi.services.operational_presence_logic import get_operational_presences_srv
 from hdx_hapi.services.sql_alchemy_session import get_db
 
@@ -14,6 +15,7 @@ router = APIRouter(
     tags=['3W'],
 )
 
+@router.get('/api/themes/3w', response_model=List[OperationalPresenceViewPydantic])
 @router.get('/api/themes/3W', response_model=List[OperationalPresenceViewPydantic])
 async def get_operational_presences(
     pagination_parameters: Annotated[dict, Depends(pagination_parameters)],
@@ -43,7 +45,7 @@ async def get_operational_presences(
     # org_type_description: Annotated[str, Query(max_length=512, description='Location name')] = None,
     # admin1_name: Annotated[str, Query(max_length=512, description='Location Adm1 Name')] = None,
 
-
+    output_format: OutputFormat = OutputFormat.JSON,
 ):
     """
     Get the list of operational presences.
@@ -75,4 +77,4 @@ async def get_operational_presences(
         # org_type_description=org_type_description, 
 
         )
-    return result
+    return transform_result_to_csv_stream_if_requested(result, output_format, OperationalPresenceViewPydantic)

--- a/hdx_hapi/endpoints/models/admin1_view.py
+++ b/hdx_hapi/endpoints/models/admin1_view.py
@@ -1,9 +1,11 @@
-from pydantic import BaseModel, Field
+from pydantic import ConfigDict, Field
 from typing import Optional
 from datetime import datetime
 
+from hdx_hapi.endpoints.models.base import HapiBaseModel
 
-class Admin1ViewPydantic(BaseModel):
+
+class Admin1ViewPydantic(HapiBaseModel):
     # id: int
     # location_ref: int
     code: str = Field(max_length=128)
@@ -12,5 +14,4 @@ class Admin1ViewPydantic(BaseModel):
     reference_period_start: datetime
     reference_period_end: Optional[datetime]
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/hdx_hapi/endpoints/models/admin2_view.py
+++ b/hdx_hapi/endpoints/models/admin2_view.py
@@ -1,9 +1,11 @@
-from pydantic import BaseModel, Field
+from pydantic import ConfigDict, Field
 from typing import Optional
 from datetime import datetime
 
+from hdx_hapi.endpoints.models.base import HapiBaseModel
 
-class Admin2ViewPydantic(BaseModel):
+
+class Admin2ViewPydantic(HapiBaseModel):
     # id: int
     # admin1_ref: int
     code: str = Field(max_length=128)
@@ -12,5 +14,4 @@ class Admin2ViewPydantic(BaseModel):
     reference_period_start: datetime
     reference_period_end: Optional[datetime]
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/hdx_hapi/endpoints/models/age_range_view.py
+++ b/hdx_hapi/endpoints/models/age_range_view.py
@@ -1,12 +1,12 @@
-from pydantic import BaseModel, Field
+from pydantic import ConfigDict, Field
 from typing import Optional
-from datetime import datetime
+
+from hdx_hapi.endpoints.models.base import HapiBaseModel
 
 
-class AgeRangeViewPydantic(BaseModel):
+class AgeRangeViewPydantic(HapiBaseModel):
     code: str = Field(max_length=32)
     age_min: int = None
     age_max: Optional[int] = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/hdx_hapi/endpoints/models/base.py
+++ b/hdx_hapi/endpoints/models/base.py
@@ -1,0 +1,7 @@
+from typing import List
+from pydantic import BaseModel
+
+
+class HapiBaseModel(BaseModel):
+    def list_of_fields(self) -> List[str]:
+        return list(self.__fields__.keys())

--- a/hdx_hapi/endpoints/models/dataset_view.py
+++ b/hdx_hapi/endpoints/models/dataset_view.py
@@ -1,9 +1,10 @@
-from pydantic import BaseModel, Field, HttpUrl, computed_field
-from typing import Optional
+from typing import List
+from pydantic import ConfigDict, Field, HttpUrl, computed_field
+from hdx_hapi.endpoints.models.base import HapiBaseModel
 from hdx_hapi.services.hdx_url_logic import get_dataset_url, get_dataset_api_url
 
 
-class DatasetViewPydantic(BaseModel):
+class DatasetViewPydantic(HapiBaseModel):
     hdx_id: str = Field(max_length=36)
     hdx_stub: str = Field(max_length=128)
     title: str = Field(max_length=1024)
@@ -24,5 +25,9 @@ class DatasetViewPydantic(BaseModel):
         return get_dataset_api_url(dataset_id=self.hdx_id)
 
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
+
+    def list_of_fields(self) -> List[str]:
+        fields = super().list_of_fields()
+        fields.extend(['hdx_link', 'api_link'])
+        return fields

--- a/hdx_hapi/endpoints/models/gender_view.py
+++ b/hdx_hapi/endpoints/models/gender_view.py
@@ -1,9 +1,10 @@
-from pydantic import BaseModel, Field
+from pydantic import ConfigDict, Field
+
+from hdx_hapi.endpoints.models.base import HapiBaseModel
 
 
-class GenderViewPydantic(BaseModel):
+class GenderViewPydantic(HapiBaseModel):
     code: str = Field(max_length=1)
     description: str = Field(max_length=256)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/hdx_hapi/endpoints/models/location_view.py
+++ b/hdx_hapi/endpoints/models/location_view.py
@@ -1,14 +1,15 @@
-from pydantic import BaseModel, Field
+from pydantic import ConfigDict, Field
 from typing import Optional
 from datetime import datetime
 
+from hdx_hapi.endpoints.models.base import HapiBaseModel
 
-class LocationViewPydantic(BaseModel):
+
+class LocationViewPydantic(HapiBaseModel):
     # id: int
     code: str = Field(max_length=128)
     name: str = Field(max_length=512)
     reference_period_start: datetime
     reference_period_end: Optional[datetime]
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/hdx_hapi/endpoints/models/operational_presence_view.py
+++ b/hdx_hapi/endpoints/models/operational_presence_view.py
@@ -1,8 +1,9 @@
-from pydantic import BaseModel, Field
-from typing import Optional
+from pydantic import ConfigDict, Field
 from datetime import datetime
 
-class OperationalPresenceViewPydantic(BaseModel):
+from hdx_hapi.endpoints.models.base import HapiBaseModel
+
+class OperationalPresenceViewPydantic(HapiBaseModel):
 
     sector_code: str = Field(max_length=32)
     dataset_hdx_stub: str = Field(max_length=128)
@@ -28,5 +29,4 @@ class OperationalPresenceViewPydantic(BaseModel):
     # org_type_description: str = Field(max_length=512),
 
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/hdx_hapi/endpoints/models/org_type_view.py
+++ b/hdx_hapi/endpoints/models/org_type_view.py
@@ -1,11 +1,10 @@
-from pydantic import BaseModel, Field
-from typing import Optional
-from datetime import datetime
+from pydantic import ConfigDict, Field
+
+from hdx_hapi.endpoints.models.base import HapiBaseModel
 
 
-class OrgTypeViewPydantic(BaseModel):
+class OrgTypeViewPydantic(HapiBaseModel):
     code: str = Field(max_length=32)
     description: str = Field(max_length=512)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/hdx_hapi/endpoints/models/org_view.py
+++ b/hdx_hapi/endpoints/models/org_view.py
@@ -1,10 +1,11 @@
-from pydantic import BaseModel, Field, HttpUrl, computed_field
-from typing import Optional
+from pydantic import ConfigDict, Field, HttpUrl, computed_field
+from typing import List, Optional
 from datetime import datetime
+from hdx_hapi.endpoints.models.base import HapiBaseModel
 from hdx_hapi.services.hdx_url_logic import get_organization_url
 
 
-class OrgViewPydantic(BaseModel):
+class OrgViewPydantic(HapiBaseModel):
     # id: int
     # hdx_link: str = Field(max_length=1024)
     acronym: str = Field(max_length=32)
@@ -18,5 +19,9 @@ class OrgViewPydantic(BaseModel):
     def hdx_link(self) -> HttpUrl:
         return get_organization_url(org_id=self.acronym)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
+
+    def list_of_fields(self) -> List[str]:
+        fields = super().list_of_fields()
+        fields.extend(['hdx_link'])
+        return fields

--- a/hdx_hapi/endpoints/models/population_view.py
+++ b/hdx_hapi/endpoints/models/population_view.py
@@ -1,11 +1,12 @@
-from datetime import datetime
-from pydantic import BaseModel, Field
+from pydantic import ConfigDict, Field
 from typing import Optional
 
+from hdx_hapi.endpoints.models.base import HapiBaseModel
 
-class PopulationViewPydantic(BaseModel):
-    gender_code: Optional[str] = Field(max_length=1,required=False)
-    age_range_code: Optional[str] = Field(max_length=32,required=False)
+
+class PopulationViewPydantic(HapiBaseModel):
+    gender_code: Optional[str] = Field(max_length=1)
+    age_range_code: Optional[str] = Field(max_length=32)
     population: int
     dataset_hdx_stub: str = Field(max_length=128)
     location_code: str = Field(max_length=128)
@@ -15,5 +16,4 @@ class PopulationViewPydantic(BaseModel):
     admin2_code: str = Field(max_length=128)
     admin2_name: str = Field(max_length=512)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/hdx_hapi/endpoints/models/resource_view.py
+++ b/hdx_hapi/endpoints/models/resource_view.py
@@ -1,8 +1,8 @@
+from typing import List
 from datetime import datetime
-from pydantic import BaseModel, Field, HttpUrl, computed_field
-from typing import Annotated, Optional
+from pydantic import ConfigDict, Field, HttpUrl, computed_field
+from hdx_hapi.endpoints.models.base import HapiBaseModel
 
-from sqlalchemy import Boolean
 from hdx_hapi.services.hdx_url_logic import (
     get_resource_url,
     get_resource_api_url,
@@ -11,7 +11,7 @@ from hdx_hapi.services.hdx_url_logic import (
 )
 
 
-class ResourceViewPydantic(BaseModel):
+class ResourceViewPydantic(HapiBaseModel):
     # id: int
     hdx_id: str = Field(max_length=36)
     filename: str = Field(max_length=256)
@@ -50,5 +50,10 @@ class ResourceViewPydantic(BaseModel):
     def dataset_api_link(self) -> HttpUrl:
         return get_dataset_api_url(dataset_id=self.dataset_hdx_id)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
+
+    def list_of_fields(self) -> List[str]:
+        fields = super().list_of_fields()
+        fields.extend(['hdx_link', 'api_link', 'dataset_hdx_link', 'dataset_api_link'])
+        return fields
+    

--- a/hdx_hapi/endpoints/models/sector_view.py
+++ b/hdx_hapi/endpoints/models/sector_view.py
@@ -1,13 +1,14 @@
-from pydantic import BaseModel, Field
+from pydantic import ConfigDict, Field
 from typing import Optional
 from datetime import datetime
 
+from hdx_hapi.endpoints.models.base import HapiBaseModel
 
-class SectorViewPydantic(BaseModel):
+
+class SectorViewPydantic(HapiBaseModel):
     code: str = Field(max_length=32)
     name: str = Field(max_length=512)
     reference_period_start: datetime
     reference_period_end: Optional[datetime]
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/hdx_hapi/endpoints/util/util.py
+++ b/hdx_hapi/endpoints/util/util.py
@@ -1,9 +1,16 @@
+from enum import Enum
 from typing import Annotated
 
 from fastapi import Query
 
 
 async def pagination_parameters(
-    offset: Annotated[int, Query(ge=0)] = 0, limit: Annotated[int, Query(ge=0, le=1000)] = 1000
+    offset: Annotated[int, Query(ge=0)] = 0, limit: Annotated[int, Query(ge=0, le=10000)] = 10000
 ):
     return {"offset": offset, "limit": limit}
+
+
+class OutputFormat(str, Enum):
+    CSV = 'csv'
+    JSON = 'json'
+

--- a/hdx_hapi/services/csv_transform_logic.py
+++ b/hdx_hapi/services/csv_transform_logic.py
@@ -1,0 +1,59 @@
+import csv
+import io
+import re
+
+from typing import Dict, List, Type
+
+from fastapi.responses import StreamingResponse
+from hdx_hapi.endpoints.models.base import HapiBaseModel
+
+from hdx_hapi.endpoints.util.util import OutputFormat
+
+
+MAX_ITEMS_IN_BATCH = 5000
+
+
+def transform_result_to_csv_stream_if_requested(
+        result: List[Dict], 
+        output_format: OutputFormat, 
+        pydantic_class: Type[HapiBaseModel]
+    ) -> List[Dict] | StreamingResponse:
+    """
+    Transforms the result to a CSV stream if requested. Otherwise, returns the result as is
+    """
+
+    if output_format == OutputFormat.CSV:
+        if result:
+            def iter_csv(): 
+                pydantic_instance = pydantic_class.model_validate(result[0])
+                keys = pydantic_instance.list_of_fields()
+                items_per_row = len(keys)
+                header_row_generated = False
+                i = 0
+                while i < len(result):
+                    total_items_in_batch = 0
+                    with io.StringIO() as str_as_file:
+                        writer = csv.writer(str_as_file)
+                        if not header_row_generated:
+                            writer.writerow(keys)
+                            header_row_generated = True
+                        while i < len(result):
+                            item = result[i]
+                            pydantic_model = pydantic_class.model_validate(item)
+                            new_row = [getattr(pydantic_model, key, '') for key in keys]
+                            writer.writerow(new_row)
+                            i += 1
+                            total_items_in_batch += items_per_row
+                            if total_items_in_batch >= MAX_ITEMS_IN_BATCH:
+                                break
+
+                        csv_row = str_as_file.getvalue()
+                        yield csv_row          
+
+            response = StreamingResponse(iter_csv(), media_type="text/csv")
+            response.headers["Content-Disposition"] = "attachment; filename=results.csv"
+            return response
+
+        return StreamingResponse(iter([]), media_type="text/csv")
+    return result
+

--- a/tests/test_endpoints/test_population_endpoint.py
+++ b/tests/test_endpoints/test_population_endpoint.py
@@ -11,6 +11,6 @@ log = logging.getLogger(__name__)
 async def test_get_populations(event_loop, refresh_db):
     log.info('started test_get_populations')
     async with AsyncClient(app=app, base_url="http://test") as ac:
-        response = await ac.get('/api/population')
+        response = await ac.get('/api/themes/population')
     assert response.status_code == 200
     assert len(response.json()) > 0, 'There should be at least one population entry in the database'


### PR DESCRIPTION
- we need a HapiBaseModel (pydantic model) in order to get the list of fields that a pydantic model has (in order to include the computed fields)
- using from_attributes=True in pydantic models to transform sqlAlchemy models (the orm_mode way was no longer supported)
- moving the population endpoint to /api/themes/population