### PR TITLE
HDX-9727 Application and email encoding in base64

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,3 +41,20 @@ URL: jdbc:postgresql://localhost:45432/hapi
 username: hapi
 password: hapi
 ```
+
+# Adding a new endpoint
+
+To add a new endpoint we add lines like this to `main.py`:
+```python
+from hdx_hapi.endpoints.get_population_profile import router as population_profile_router  # noqa
+```
+
+Followed by:
+```python
+app.include_router(population_profile_router)
+```
+
+The route is implemented in the `hdx_hapi/endpoints` directory based on a FastAPI `APIRouter`. `pagingination_parameters` and `OutputFormat` are provided as parameters for all endpoints. The model for the response is provided in the `hdx_hapi/endpoints/models` directory, derived from the HapiBaseModel which is itself derived from the `pydantic.BaseModel`
+
+Tests are created by adding dictionary entries with `query_parameters` and `expected_fields` to the `tests/endpoint_data.py` file. Three tests are then done in a dedicated test file, one for any response, one for the query parameters and one for the response.
+

--- a/hdx_hapi/endpoints/get_encoded_identifier.py
+++ b/hdx_hapi/endpoints/get_encoded_identifier.py
@@ -1,0 +1,37 @@
+from typing import Annotated
+from fastapi import APIRouter, Depends, Query
+from hdx_hapi.services.csv_transform_logic import transform_result_to_csv_stream_if_requested
+
+from hdx_hapi.endpoints.models.encoded_identifier import IdentifierResponse
+from hdx_hapi.endpoints.util.util import OutputFormat, pagination_parameters
+
+router = APIRouter(
+    tags=['Utility'],
+)
+
+SUMMARY = 'Get an encoded application name plus email'
+
+
+@router.get(
+    '/api/encode_identifier',
+    response_model=IdentifierResponse,
+    summary=SUMMARY,
+    include_in_schema=False,
+)
+@router.get(
+    '/api/v1/encode_identifier',
+    response_model=IdentifierResponse,
+    summary=SUMMARY,
+)
+async def get_encoded_identifier(
+    pagination_parameters: Annotated[dict, Depends(pagination_parameters)],
+    application: Annotated[str, Query(max_length=512, description='A name for the calling application')] = None,
+    email: Annotated[str, Query(max_length=512, description='An email address')] = None,
+    output_format: OutputFormat = OutputFormat.JSON,
+):
+    """
+    Get information about the <a href="https://data.humdata.org/dataset">HDX Datasets</a> that are used as data sources
+    for HAPI. Datasets contain one or more resources, which are the sources of the data found in HAPI.
+    """
+    result = {'encoded_identifier': f'{application}:{email}'}
+    return transform_result_to_csv_stream_if_requested(result, output_format, IdentifierResponse)

--- a/hdx_hapi/endpoints/get_encoded_identifier.py
+++ b/hdx_hapi/endpoints/get_encoded_identifier.py
@@ -1,3 +1,4 @@
+import base64
 from typing import Annotated
 from fastapi import APIRouter, Depends, Query
 from hdx_hapi.services.csv_transform_logic import transform_result_to_csv_stream_if_requested
@@ -30,8 +31,9 @@ async def get_encoded_identifier(
     output_format: OutputFormat = OutputFormat.JSON,
 ):
     """
-    Get information about the <a href="https://data.humdata.org/dataset">HDX Datasets</a> that are used as data sources
-    for HAPI. Datasets contain one or more resources, which are the sources of the data found in HAPI.
+    Encode an application name and email address in base64 to serve as an client identifier in HAPI calls
     """
-    result = {'encoded_identifier': f'{application}:{email}'}
+    encoded_identifier = base64.b64encode(bytes(f'{application}:{email}', 'utf-8'))
+
+    result = {'encoded_identifier': encoded_identifier.decode('utf-8')}
     return transform_result_to_csv_stream_if_requested(result, output_format, IdentifierResponse)

--- a/hdx_hapi/endpoints/models/encoded_identifier.py
+++ b/hdx_hapi/endpoints/models/encoded_identifier.py
@@ -1,0 +1,6 @@
+from pydantic import Field
+from hdx_hapi.endpoints.models.base import HapiBaseModel
+
+
+class IdentifierResponse(HapiBaseModel):
+    encoded_identifier: str = Field(max_length=512)

--- a/main.py
+++ b/main.py
@@ -1,25 +1,27 @@
 import logging
 import logging.config
+
 logging.config.fileConfig('logging.conf')
 
-import uvicorn # noqa
-from fastapi import FastAPI, Request # noqa
-from fastapi.responses import HTMLResponse, RedirectResponse # noqa
-from fastapi.openapi.docs import get_swagger_ui_html # noqa
+import uvicorn  # noqa
+from fastapi import FastAPI, Request  # noqa
+from fastapi.responses import HTMLResponse, RedirectResponse  # noqa
+from fastapi.openapi.docs import get_swagger_ui_html  # noqa
 
 # from hdx_hapi.services.sql_alchemy_session import init_db
 
-from hdx_hapi.endpoints.favicon import router as favicon_router # noqa
-from hdx_hapi.endpoints.get_population import router as population_router # noqa
-from hdx_hapi.endpoints.get_operational_presence import router as operational_presence_router # noqa
-from hdx_hapi.endpoints.get_admin_level import router as admin_level_router # noqa
-from hdx_hapi.endpoints.get_hdx_metadata import router as dataset_router # noqa
-from hdx_hapi.endpoints.get_humanitarian_response import router as humanitarian_response_router # noqa
-from hdx_hapi.endpoints.get_demographic import router as demographic_router # noqa
-from hdx_hapi.endpoints.get_food_security import router as food_security_router # noqa 
-from hdx_hapi.endpoints.get_national_risk import router as national_risk_router # noqa
-from hdx_hapi.endpoints.get_humanitarian_needs import router as humanitarian_needs_router # noqa
-from hdx_hapi.endpoints.get_population_profile import router as population_profile_router # noqa
+from hdx_hapi.endpoints.favicon import router as favicon_router  # noqa
+from hdx_hapi.endpoints.get_population import router as population_router  # noqa
+from hdx_hapi.endpoints.get_operational_presence import router as operational_presence_router  # noqa
+from hdx_hapi.endpoints.get_admin_level import router as admin_level_router  # noqa
+from hdx_hapi.endpoints.get_hdx_metadata import router as dataset_router  # noqa
+from hdx_hapi.endpoints.get_humanitarian_response import router as humanitarian_response_router  # noqa
+from hdx_hapi.endpoints.get_demographic import router as demographic_router  # noqa
+from hdx_hapi.endpoints.get_food_security import router as food_security_router  # noqa
+from hdx_hapi.endpoints.get_national_risk import router as national_risk_router  # noqa
+from hdx_hapi.endpoints.get_humanitarian_needs import router as humanitarian_needs_router  # noqa
+from hdx_hapi.endpoints.get_population_profile import router as population_profile_router  # noqa
+from hdx_hapi.endpoints.get_encoded_identifier import router as encoded_identifier_router  # noqa
 
 
 # from hdx_hapi.endpoints.delete_example import delete_dataset
@@ -30,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI(
     title='HAPI',
-    description='The Humanitarian API (HAPI) is a service of the <a href="https://data.humdata.org">Humanitarian Data Exchange (HDX)</a>, part of UNOCHA\'s <a href="https://centre.humdata.org">Centre for Humanitarian Data</a>.\nThis is the reference documentation of the API. You may want to <a href="https://hdx-hapi.readthedocs.io/en/latest/">get started here</a>', # noqa
+    description='The Humanitarian API (HAPI) is a service of the <a href="https://data.humdata.org">Humanitarian Data Exchange (HDX)</a>, part of UNOCHA\'s <a href="https://centre.humdata.org">Centre for Humanitarian Data</a>.\nThis is the reference documentation of the API. You may want to <a href="https://hdx-hapi.readthedocs.io/en/latest/">get started here</a>',  # noqa
     version='0.1.0',
     docs_url=None,
 )
@@ -47,7 +49,7 @@ app.include_router(humanitarian_response_router)
 app.include_router(demographic_router)
 app.include_router(population_profile_router)
 app.include_router(dataset_router)
-
+app.include_router(encoded_identifier_router)
 
 
 @app.on_event('startup')
@@ -57,7 +59,7 @@ async def startup():
     pass
 
 
-# Adding custom favicon based on article 
+# Adding custom favicon based on article
 @app.get('/docs', include_in_schema=False)
 async def swagger_ui_html(req: Request) -> HTMLResponse:
     root_path = req.scope.get('root_path', '').rstrip('/')
@@ -79,5 +81,6 @@ async def swagger_ui_html(req: Request) -> HTMLResponse:
 def home():
     return RedirectResponse('/docs')
 
+
 if __name__ == '__main__':
-    uvicorn.run(app, host='0.0.0.0',port=8844, log_config='logging.conf')
+    uvicorn.run(app, host='0.0.0.0', port=8844, log_config='logging.conf')

--- a/tests/test_endpoints/endpoint_data.py
+++ b/tests/test_endpoints/endpoint_data.py
@@ -8,12 +8,7 @@ endpoint_data = {
             'location_code': 'FoO',
             'location_name': 'Foolandia',
         },
-        'expected_fields': [
-            'code',
-            'name',
-            'location_code',
-            'location_name'
-        ],
+        'expected_fields': ['code', 'name', 'location_code', 'location_name'],
     },
     '/api/admin2': {
         'query_parameters': {
@@ -24,24 +19,11 @@ endpoint_data = {
             'location_code': 'FOo',
             'location_name': 'Foolandia',
         },
-        'expected_fields': [
-            'code',
-            'name',
-            'admin1_code',
-            'admin1_name',
-            'location_code',
-            'location_name'
-        ],
+        'expected_fields': ['code', 'name', 'admin1_code', 'admin1_name', 'location_code', 'location_name'],
     },
     '/api/age_range': {
-        'query_parameters': {
-            'code': '10-14'
-        },
-        'expected_fields': [
-            'code',
-            'age_min',
-            'age_max'
-        ],
+        'query_parameters': {'code': '10-14'},
+        'expected_fields': ['code', 'age_min', 'age_max'],
     },
     '/api/dataset': {
         'query_parameters': {
@@ -57,28 +39,16 @@ endpoint_data = {
             'hdx_provider_stub',
             'hdx_provider_name',
             'hdx_link',  # computed field
-            'hdx_api_link'  # computed field
+            'hdx_api_link',  # computed field
         ],
     },
     '/api/gender': {
-        'query_parameters': {
-            'code': 'F',
-            'name': 'female'
-        },
-        'expected_fields': [
-            'code',
-            'description'
-        ],
+        'query_parameters': {'code': 'F', 'name': 'female'},
+        'expected_fields': ['code', 'description'],
     },
     '/api/location': {
-        'query_parameters': {
-            'code': 'foo',
-            'name': 'Foolandia'
-        },
-        'expected_fields': [
-            'code',
-            'name'
-        ],
+        'query_parameters': {'code': 'foo', 'name': 'Foolandia'},
+        'expected_fields': ['code', 'name'],
     },
     '/api/themes/3W': {
         'query_parameters': {
@@ -111,7 +81,7 @@ endpoint_data = {
             'admin1_code',
             'admin1_name',
             'admin2_code',
-            'admin2_name'
+            'admin2_name',
         ],
     },
     '/api/org': {
@@ -121,22 +91,14 @@ endpoint_data = {
             'org_type_code': '433',
             'org_type_description': 'Dono',  # Donor
         },
-        'expected_fields': [
-            'acronym',
-            'name',
-            'org_type_code',
-            'org_type_description'
-        ],
+        'expected_fields': ['acronym', 'name', 'org_type_code', 'org_type_description'],
     },
     '/api/org_type': {
         'query_parameters': {
             'code': '431',
-            'name': 'national'  # International
+            'name': 'national',  # International
         },
-        'expected_fields': [
-            'code',
-            'description'
-        ],
+        'expected_fields': ['code', 'description'],
     },
     '/api/themes/population': {
         'query_parameters': {
@@ -167,28 +129,19 @@ endpoint_data = {
             'admin1_code',
             'admin1_name',
             'admin2_code',
-            'admin2_name'
+            'admin2_name',
         ],
     },
     '/api/population_group': {
         'query_parameters': {
             'code': 'refugees',
-            'description': 'refugee'  # refugees
+            'description': 'refugee',  # refugees
         },
-        'expected_fields': [
-            'code',
-            'description'
-        ],
+        'expected_fields': ['code', 'description'],
     },
     '/api/population_status': {
-        'query_parameters': {
-            'code': 'inneed',
-            'description': 'people'
-        },
-        'expected_fields': [
-            'code',
-            'description'
-        ],
+        'query_parameters': {'code': 'inneed', 'description': 'people'},
+        'expected_fields': ['code', 'description'],
     },
     '/api/themes/food_security': {
         'query_parameters': {
@@ -221,7 +174,7 @@ endpoint_data = {
             'admin1_code',
             'admin1_name',
             'admin2_code',
-            'admin2_name'
+            'admin2_name',
         ],
     },
     '/api/themes/national_risk': {
@@ -255,7 +208,7 @@ endpoint_data = {
             'resource_hdx_id',
             # "sector_name",
             'location_code',
-            'location_name'
+            'location_name',
         ],
     },
     '/api/themes/humanitarian_needs': {
@@ -298,7 +251,7 @@ endpoint_data = {
             'admin1_code',
             'admin1_name',
             'admin2_code',
-            'admin2_name'
+            'admin2_name',
         ],
     },
     '/api/resource': {
@@ -334,11 +287,15 @@ endpoint_data = {
     '/api/sector': {
         'query_parameters': {
             'code': 'Pro',
-            'name': 'Protect'  # Protection
+            'name': 'Protect',  # Protection
         },
-        'expected_fields': [
-            'code',
-            'name'
-        ],
+        'expected_fields': ['code', 'name'],
+    },
+    '/api/encode_identifier': {
+        'query_parameters': {
+            'application': 'web_application_1',
+            'email': 'info@example.com',
+        },
+        'expected_fields': ['encoded_identifier'],
     },
 }

--- a/tests/test_endpoints/test_encode_identifier.py
+++ b/tests/test_endpoints/test_encode_identifier.py
@@ -1,3 +1,4 @@
+import base64
 import pytest
 import logging
 
@@ -55,4 +56,7 @@ async def test_get_encoded_identifier_results(event_loop, refresh_db):
         assert field in response.json(), f'Field "{field}" not found in the response'
 
     assert len(response.json()) == len(expected_fields), 'Response has a different number of fields than expected'
-    assert response.json() == {'encoded_identifier': 'web_application_1:info@example.com'}
+    assert response.json() == {'encoded_identifier': 'd2ViX2FwcGxpY2F0aW9uXzE6aW5mb0BleGFtcGxlLmNvbQ=='}
+    assert (
+        base64.b64decode(response.json()['encoded_identifier']).decode('utf-8') == 'web_application_1:info@example.com'
+    )

--- a/tests/test_endpoints/test_encode_identifier.py
+++ b/tests/test_endpoints/test_encode_identifier.py
@@ -1,0 +1,58 @@
+import pytest
+import logging
+
+from httpx import AsyncClient
+from main import app
+from tests.test_endpoints.endpoint_data import endpoint_data
+
+log = logging.getLogger(__name__)
+
+ENDPOINT_ROUTER = '/api/encode_identifier'
+endpoint_data = endpoint_data[ENDPOINT_ROUTER]
+query_parameters = endpoint_data['query_parameters']
+expected_fields = endpoint_data['expected_fields']
+
+
+@pytest.mark.asyncio
+async def test_get_encoded_identifier(event_loop, refresh_db):
+    log.info('started test_get_encoded_identifier')
+    async with AsyncClient(app=app, base_url='http://test') as ac:
+        response = await ac.get(ENDPOINT_ROUTER)
+    assert response.status_code == 200
+    response_items = response.json()
+    assert len(response_items) == 1, 'One entry should be returned for encoded identifier'
+
+
+@pytest.mark.asyncio
+async def test_get_encoded_identifier_params(event_loop, refresh_db):
+    log.info('started test_get_encoded_identifier_params')
+
+    for param_name, param_value in query_parameters.items():
+        async with AsyncClient(app=app, base_url='http://test', params={param_name: param_value}) as ac:
+            response = await ac.get(ENDPOINT_ROUTER)
+
+        assert response.status_code == 200
+        assert len(response.json()) == 1, (
+            'There should be at one encoded_identifier entry for parameter '
+            f'"{param_name}" with value "{param_value}" in the database'
+        )
+
+    async with AsyncClient(app=app, base_url='http://test', params=query_parameters) as ac:
+        response = await ac.get(ENDPOINT_ROUTER)
+
+    assert response.status_code == 200
+    assert len(response.json()) == 1, 'There should be at one encoded_identifier entry for all parameters'
+
+
+@pytest.mark.asyncio
+async def test_get_encoded_identifier_results(event_loop, refresh_db):
+    log.info('started test_get_encoded_identifier_result')
+
+    async with AsyncClient(app=app, base_url='http://test', params=query_parameters) as ac:
+        response = await ac.get(ENDPOINT_ROUTER)
+
+    for field in expected_fields:
+        assert field in response.json(), f'Field "{field}" not found in the response'
+
+    assert len(response.json()) == len(expected_fields), 'Response has a different number of fields than expected'
+    assert response.json() == {'encoded_identifier': 'web_application_1:info@example.com'}


### PR DESCRIPTION
This PR adds a route to the API (encode_identifier) which provides a base64 encoding of the client application name and email address. They are concatenated as `application_name:email`.

The PR includes tests of the endpint and documentation. The tests demonstrate roundtripping of the application_name and email address.

Currently the route includes pagination_parameters and OutputFormat, however, perhaps uniquely the `encode_identifier` returns a single response rather than a list of responses. Therefore a modification required is to either return a list of responses, or remove the pagination and OutputFormat parameters.

A section has been added to `CONTRIBUTING.md` to describe the process of adding a new route. 

