### PR TITLE
HDX-9729 Finish off application-email encoder

### DIFF
--- a/hdx_hapi/endpoints/get_encoded_identifier.py
+++ b/hdx_hapi/endpoints/get_encoded_identifier.py
@@ -1,10 +1,10 @@
 import base64
 from typing import Annotated
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Query
 from hdx_hapi.services.csv_transform_logic import transform_result_to_csv_stream_if_requested
 
 from hdx_hapi.endpoints.models.encoded_identifier import IdentifierResponse
-from hdx_hapi.endpoints.util.util import OutputFormat, pagination_parameters
+from hdx_hapi.endpoints.util.util import OutputFormat
 
 router = APIRouter(
     tags=['Utility'],
@@ -25,10 +25,8 @@ SUMMARY = 'Get an encoded application name plus email'
     summary=SUMMARY,
 )
 async def get_encoded_identifier(
-    pagination_parameters: Annotated[dict, Depends(pagination_parameters)],
     application: Annotated[str, Query(max_length=512, description='A name for the calling application')] = None,
     email: Annotated[str, Query(max_length=512, description='An email address')] = None,
-    output_format: OutputFormat = OutputFormat.JSON,
 ):
     """
     Encode an application name and email address in base64 to serve as an client identifier in HAPI calls
@@ -36,4 +34,4 @@ async def get_encoded_identifier(
     encoded_identifier = base64.b64encode(bytes(f'{application}:{email}', 'utf-8'))
 
     result = {'encoded_identifier': encoded_identifier.decode('utf-8')}
-    return transform_result_to_csv_stream_if_requested(result, output_format, IdentifierResponse)
+    return transform_result_to_csv_stream_if_requested(result, OutputFormat.JSON, IdentifierResponse)

--- a/hdx_hapi/endpoints/get_encoded_identifier.py
+++ b/hdx_hapi/endpoints/get_encoded_identifier.py
@@ -1,6 +1,7 @@
 import base64
 from typing import Annotated
 from fastapi import APIRouter, Query
+from pydantic import EmailStr
 from hdx_hapi.services.csv_transform_logic import transform_result_to_csv_stream_if_requested
 
 from hdx_hapi.endpoints.models.encoded_identifier import IdentifierResponse
@@ -26,7 +27,7 @@ SUMMARY = 'Get an encoded application name plus email'
 )
 async def get_encoded_identifier(
     application: Annotated[str, Query(max_length=512, description='A name for the calling application')] = None,
-    email: Annotated[str, Query(max_length=512, description='An email address')] = None,
+    email: Annotated[EmailStr, Query(max_length=512, description='An email address')] = None,
 ):
     """
     Encode an application name and email address in base64 to serve as an client identifier in HAPI calls

--- a/main.py
+++ b/main.py
@@ -10,6 +10,8 @@ from fastapi.openapi.docs import get_swagger_ui_html  # noqa
 
 # from hdx_hapi.services.sql_alchemy_session import init_db
 
+from hdx_hapi.endpoints.get_encoded_identifier import router as encoded_identifier_router  # noqa
+
 from hdx_hapi.endpoints.favicon import router as favicon_router  # noqa
 from hdx_hapi.endpoints.get_population import router as population_router  # noqa
 from hdx_hapi.endpoints.get_operational_presence import router as operational_presence_router  # noqa
@@ -21,7 +23,6 @@ from hdx_hapi.endpoints.get_food_security import router as food_security_router 
 from hdx_hapi.endpoints.get_national_risk import router as national_risk_router  # noqa
 from hdx_hapi.endpoints.get_humanitarian_needs import router as humanitarian_needs_router  # noqa
 from hdx_hapi.endpoints.get_population_profile import router as population_profile_router  # noqa
-from hdx_hapi.endpoints.get_encoded_identifier import router as encoded_identifier_router  # noqa
 
 
 # from hdx_hapi.endpoints.delete_example import delete_dataset
@@ -37,7 +38,7 @@ app = FastAPI(
     docs_url=None,
 )
 
-
+app.include_router(encoded_identifier_router)
 app.include_router(favicon_router)
 app.include_router(operational_presence_router)
 app.include_router(population_router)
@@ -49,7 +50,6 @@ app.include_router(humanitarian_response_router)
 app.include_router(demographic_router)
 app.include_router(population_profile_router)
 app.include_router(dataset_router)
-app.include_router(encoded_identifier_router)
 
 
 @app.on_event('startup')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ uvicorn[standard]~=0.23.2
 sqlalchemy[asyncio]~=2.0.20
 asyncpg~=0.28.0
 python-json-logger~=2.0.7
+email_validator~=2.1.1
 
 alembic~=1.12.00
 psycopg2~=2.9.7

--- a/tests/test_endpoints/test_encode_identifier.py
+++ b/tests/test_endpoints/test_encode_identifier.py
@@ -75,7 +75,10 @@ async def test_email_validation(event_loop, refresh_db):
             {
                 'type': 'value_error',
                 'loc': ['query', 'email'],
-                'msg': 'value is not a valid email address: The email address is not valid. It must have exactly one @-sign.',
+                'msg': (
+                    'value is not a valid email address: The email address is not valid. '
+                    'It must have exactly one @-sign.'
+                ),
                 'input': 'not_an_email',
                 'ctx': {'reason': 'The email address is not valid. It must have exactly one @-sign.'},
             }

--- a/tests/test_endpoints/test_encode_identifier.py
+++ b/tests/test_endpoints/test_encode_identifier.py
@@ -60,3 +60,24 @@ async def test_get_encoded_identifier_results(event_loop, refresh_db):
     assert (
         base64.b64decode(response.json()['encoded_identifier']).decode('utf-8') == 'web_application_1:info@example.com'
     )
+
+
+@pytest.mark.asyncio
+async def test_email_validation(event_loop, refresh_db):
+    log.info('started test_get_encoded_identifier_result')
+
+    query_parameters = {'application': 'web_application', 'email': 'not_an_email'}
+    async with AsyncClient(app=app, base_url='http://test', params=query_parameters) as ac:
+        response = await ac.get(ENDPOINT_ROUTER)
+
+    assert response.json() == {
+        'detail': [
+            {
+                'type': 'value_error',
+                'loc': ['query', 'email'],
+                'msg': 'value is not a valid email address: The email address is not valid. It must have exactly one @-sign.',
+                'input': 'not_an_email',
+                'ctx': {'reason': 'The email address is not valid. It must have exactly one @-sign.'},
+            }
+        ]
+    }


### PR DESCRIPTION
This PR fixes three small issues arising from the first implementation of this feature:
1. Pagination and OutputFormat parameters are removed because they are not relevant to this query.
2. The documentation for the encode_identifier endpoint is moved to the top of the docs page
3. The email parameter is given the Pydantic "EmailStr" type which invokes some validation of the provided email address (this is tested).

