### PR TITLE
HDX-9799 Disallow calls to encode identifier with no parameters

### DIFF
--- a/hdx_hapi/endpoints/get_encoded_identifier.py
+++ b/hdx_hapi/endpoints/get_encoded_identifier.py
@@ -26,8 +26,8 @@ SUMMARY = 'Get an encoded application name plus email'
     summary=SUMMARY,
 )
 async def get_encoded_identifier(
-    application: Annotated[str, Query(max_length=512, description='A name for the calling application')] = None,
-    email: Annotated[EmailStr, Query(max_length=512, description='An email address')] = None,
+    application: Annotated[str, Query(max_length=512, description='A name for the calling application')],
+    email: Annotated[EmailStr, Query(max_length=512, description='An email address')],
 ):
     """
     Encode an application name and email address in base64 to serve as an client identifier in HAPI calls

--- a/tests/test_endpoints/test_encode_identifier.py
+++ b/tests/test_endpoints/test_encode_identifier.py
@@ -15,37 +15,6 @@ expected_fields = endpoint_data['expected_fields']
 
 
 @pytest.mark.asyncio
-async def test_get_encoded_identifier(event_loop, refresh_db):
-    log.info('started test_get_encoded_identifier')
-    async with AsyncClient(app=app, base_url='http://test') as ac:
-        response = await ac.get(ENDPOINT_ROUTER)
-    assert response.status_code == 200
-    response_items = response.json()
-    assert len(response_items) == 1, 'One entry should be returned for encoded identifier'
-
-
-@pytest.mark.asyncio
-async def test_get_encoded_identifier_params(event_loop, refresh_db):
-    log.info('started test_get_encoded_identifier_params')
-
-    for param_name, param_value in query_parameters.items():
-        async with AsyncClient(app=app, base_url='http://test', params={param_name: param_value}) as ac:
-            response = await ac.get(ENDPOINT_ROUTER)
-
-        assert response.status_code == 200
-        assert len(response.json()) == 1, (
-            'There should be at one encoded_identifier entry for parameter '
-            f'"{param_name}" with value "{param_value}" in the database'
-        )
-
-    async with AsyncClient(app=app, base_url='http://test', params=query_parameters) as ac:
-        response = await ac.get(ENDPOINT_ROUTER)
-
-    assert response.status_code == 200
-    assert len(response.json()) == 1, 'There should be at one encoded_identifier entry for all parameters'
-
-
-@pytest.mark.asyncio
 async def test_encoded_identifier_refuses_empty_parameters(event_loop, refresh_db):
     log.info('started test_encoded_identifier_refuses_empty_parameters')
 

--- a/tests/test_endpoints/test_encode_identifier.py
+++ b/tests/test_endpoints/test_encode_identifier.py
@@ -46,6 +46,34 @@ async def test_get_encoded_identifier_params(event_loop, refresh_db):
 
 
 @pytest.mark.asyncio
+async def test_encoded_identifier_refuses_empty_parameters(event_loop, refresh_db):
+    log.info('started test_encoded_identifier_refuses_empty_parameters')
+
+    async with AsyncClient(app=app, base_url='http://test') as ac:
+        response = await ac.get(ENDPOINT_ROUTER)
+
+    assert response.status_code == 422
+    assert response.json() == {
+        'detail': [
+            {
+                'type': 'missing',
+                'loc': ['query', 'application'],
+                'msg': 'Field required',
+                'input': None,
+                'url': 'https://errors.pydantic.dev/2.6/v/missing',
+            },
+            {
+                'type': 'missing',
+                'loc': ['query', 'email'],
+                'msg': 'Field required',
+                'input': None,
+                'url': 'https://errors.pydantic.dev/2.6/v/missing',
+            },
+        ]
+    }
+
+
+@pytest.mark.asyncio
 async def test_get_encoded_identifier_results(event_loop, refresh_db):
     log.info('started test_get_encoded_identifier_result')
 

--- a/tests/test_endpoints/test_encode_identifier.py
+++ b/tests/test_endpoints/test_encode_identifier.py
@@ -1,6 +1,7 @@
 import base64
 import pytest
 import logging
+from unittest.mock import ANY
 
 from httpx import AsyncClient
 from main import app
@@ -22,23 +23,11 @@ async def test_encoded_identifier_refuses_empty_parameters(event_loop, refresh_d
         response = await ac.get(ENDPOINT_ROUTER)
 
     assert response.status_code == 422
-    print(response.json())
+    # The url key depends on the Pydantic version which we do not pin
     assert response.json() == {
         'detail': [
-            {
-                'type': 'missing',
-                'loc': ['query', 'application'],
-                'msg': 'Field required',
-                'input': None,
-                'url': 'https://errors.pydantic.dev/2.6/v/missing',
-            },
-            {
-                'type': 'missing',
-                'loc': ['query', 'email'],
-                'msg': 'Field required',
-                'input': None,
-                'url': 'https://errors.pydantic.dev/2.6/v/missing',
-            },
+            {'type': 'missing', 'loc': ['query', 'application'], 'msg': 'Field required', 'input': None, 'url': ANY},
+            {'type': 'missing', 'loc': ['query', 'email'], 'msg': 'Field required', 'input': None, 'url': ANY},
         ]
     }
 

--- a/tests/test_endpoints/test_encode_identifier.py
+++ b/tests/test_endpoints/test_encode_identifier.py
@@ -22,6 +22,7 @@ async def test_encoded_identifier_refuses_empty_parameters(event_loop, refresh_d
         response = await ac.get(ENDPOINT_ROUTER)
 
     assert response.status_code == 422
+    print(response.json())
     assert response.json() == {
         'detail': [
             {


### PR DESCRIPTION
This is a fix for "encode_identifier" returning a value and a 200 status even when no query parameters were provided.

The origin of the bug is that the FastAPI defaulted the parameters to the value None. This appears to have passed validation because it indicated that None was an allowed value. 

The value returned when no parameters were supplied by the user decodes to "None:None"