### PR TITLE
PR HDX-9852 use app_identifier instead of identifier throughout the API

### DIFF
--- a/hdx_hapi/endpoints/get_encoded_identifier.py
+++ b/hdx_hapi/endpoints/get_encoded_identifier.py
@@ -7,20 +7,20 @@ from hdx_hapi.endpoints.models.encoded_identifier import IdentifierResponse
 from hdx_hapi.endpoints.util.util import app_name_identifier_query, email_identifier_query
 
 router = APIRouter(
-    tags=['Utility'],
+    tags=['Generate App Identifier'],
 )
 
 SUMMARY = 'Get an encoded application name plus email'
 
 
 @router.get(
-    '/api/encode_identifier',
+    '/api/encode_app_identifier',
     response_model=IdentifierResponse,
     summary=SUMMARY,
     include_in_schema=False,
 )
 @router.get(
-    '/api/v1/encode_identifier',
+    '/api/v1/encode_app_identifier',
     response_model=IdentifierResponse,
     summary=SUMMARY,
 )
@@ -33,6 +33,5 @@ async def get_encoded_identifier(
     """
     encoded_identifier = base64.b64encode(bytes(f'{application}:{email}', 'utf-8'))
 
-    result = {'encoded_identifier': encoded_identifier.decode('utf-8')}
+    result = {'encoded_app_identifier': encoded_identifier.decode('utf-8')}
     return result
-    # return transform_result_to_csv_stream_if_requested(result, OutputFormat.JSON, IdentifierResponse)

--- a/hdx_hapi/endpoints/middleware/app_identifier_middleware.py
+++ b/hdx_hapi/endpoints/middleware/app_identifier_middleware.py
@@ -15,8 +15,8 @@ CONFIG = get_config()
 
 
 ALLOWED_API_ENDPOINTS = {
-    '/api/v1/encode_identifier',
-    '/api/encode_identifier',
+    '/api/v1/encode_app_identifier',
+    '/api/encode_app_identifier',
 }
 
 

--- a/hdx_hapi/endpoints/models/encoded_identifier.py
+++ b/hdx_hapi/endpoints/models/encoded_identifier.py
@@ -3,4 +3,4 @@ from hdx_hapi.endpoints.models.base import HapiBaseModel
 
 
 class IdentifierResponse(HapiBaseModel):
-    encoded_identifier: str = Field(max_length=512)
+    encoded_app_identifier: str = Field(max_length=512)

--- a/hdx_hapi/endpoints/util/util.py
+++ b/hdx_hapi/endpoints/util/util.py
@@ -12,7 +12,8 @@ _OFFSET_DESCRIPTION = (
 )
 _APP_IDENTIFIER_DESCRIPTION = (
     'base64 encoded application name and email, as in `base64("app_name:email")`. '
-    'This value can also be passed in the `X-HDX-HAPI-APP-IDENTIFIER` header. See the *encode_identifier* endpoint.'
+    'This value can also be passed in the `X-HDX-HAPI-APP-IDENTIFIER` header. '
+    'See the *encoded_app_identifier* endpoint.'
 )
 
 app_name_identifier_query = Query(max_length=512, min_length=4, description='A name for the calling application')

--- a/tests/test_endpoints/endpoint_data.py
+++ b/tests/test_endpoints/endpoint_data.py
@@ -425,11 +425,11 @@ endpoint_data = {
         },
         'expected_fields': ['code', 'name'],
     },
-    '/api/encode_identifier': {
+    '/api/encode_app_identifier': {
         'query_parameters': {
             'application': 'web_application_1',
             'email': 'info@example.com',
         },
-        'expected_fields': ['encoded_identifier'],
+        'expected_fields': ['encoded_app_identifier'],
     },
 }

--- a/tests/test_endpoints/test_encode_identifier.py
+++ b/tests/test_endpoints/test_encode_identifier.py
@@ -9,7 +9,7 @@ from tests.test_endpoints.endpoint_data import endpoint_data
 
 log = logging.getLogger(__name__)
 
-ENDPOINT_ROUTER = '/api/encode_identifier'
+ENDPOINT_ROUTER = '/api/encode_app_identifier'
 endpoint_data = endpoint_data[ENDPOINT_ROUTER]
 query_parameters = endpoint_data['query_parameters']
 expected_fields = endpoint_data['expected_fields']
@@ -43,9 +43,10 @@ async def test_get_encoded_identifier_results(event_loop, refresh_db):
         assert field in response.json(), f'Field "{field}" not found in the response'
 
     assert len(response.json()) == len(expected_fields), 'Response has a different number of fields than expected'
-    assert response.json() == {'encoded_identifier': 'd2ViX2FwcGxpY2F0aW9uXzE6aW5mb0BleGFtcGxlLmNvbQ=='}
+    assert response.json() == {'encoded_app_identifier': 'd2ViX2FwcGxpY2F0aW9uXzE6aW5mb0BleGFtcGxlLmNvbQ=='}
     assert (
-        base64.b64decode(response.json()['encoded_identifier']).decode('utf-8') == 'web_application_1:info@example.com'
+        base64.b64decode(response.json()['encoded_app_identifier']).decode('utf-8')
+        == 'web_application_1:info@example.com'
     )
 
 

--- a/tests/test_endpoints/test_endpoints_vs_encode_identifier.py
+++ b/tests/test_endpoints/test_endpoints_vs_encode_identifier.py
@@ -52,7 +52,7 @@ async def test_endpoints_vs_encode_identifier(event_loop, refresh_db, enable_hap
 @pytest.mark.asyncio
 async def test_encode_identifier(event_loop, refresh_db, enable_hapi_identifier_filtering):
     # testing the encode identifier endpoint
-    endpoint_router = '/api/v1/encode_identifier'
+    endpoint_router = '/api/v1/encode_app_identifier'
 
     # it should not be important if app_identifier is passed or not to the endpoint
     async with AsyncClient(app=app, base_url='http://test') as ac:


### PR DESCRIPTION
Instead of “Utility” -> “Generate App Identifier”

Instead of encode_identifier (endpoint name) -> encode_app_identifier

Instead of encoded_identifier in the response -> encoded_app_identifier

Changed also description for app_identifier query param to mention encode_app_identifier