### PR TITLE
HDX-9858 Set limit for examples to 100 from 1000

### DIFF
--- a/hdx_hapi/endpoints/util/util.py
+++ b/hdx_hapi/endpoints/util/util.py
@@ -19,7 +19,7 @@ _APP_IDENTIFIER_DESCRIPTION = (
 app_name_identifier_query = Query(max_length=512, min_length=4, description='A name for the calling application')
 email_identifier_query = Query(max_length=512, description='An email address')
 
-pagination_limit_query = Query(ge=0, le=10000, example=1000, description=_LIMIT_DESCRIPTION)
+pagination_limit_query = Query(ge=0, le=10000, example=100, description=_LIMIT_DESCRIPTION)
 pagination_offset_query = Query(ge=0, description=_OFFSET_DESCRIPTION)
 common_app_identifier_query = Query(max_length=512, description=_APP_IDENTIFIER_DESCRIPTION)
 


### PR DESCRIPTION
This PR reduces the limit for example queries from 1000 to 100. The default behaviour of returning 1000 rows when no limit is supplied is retained.