### PR TITLE
PR Feature/ new /verify-request for nginx

### DIFF
--- a/hdx_hapi/endpoints/get_request_verification.py
+++ b/hdx_hapi/endpoints/get_request_verification.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter
+
+router = APIRouter(
+    tags=['Nginx'],
+)
+
+
+@router.get(
+    '/api/util/verify-request',
+    response_model=None,
+    include_in_schema=False,
+)
+@router.get(
+    '/api/v1/util/verify-request',
+    response_model=None,
+    include_in_schema=False,
+)
+async def get_request_verification():
+    return None

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from hdx_hapi.endpoints.middleware.app_identifier_middleware import app_identifi
 from hdx_hapi.endpoints.middleware.mixpanel_tracking_middleware import mixpanel_tracking_middleware  # noqa
 
 from hdx_hapi.endpoints.get_encoded_identifier import router as encoded_identifier_router  # noqa
+from hdx_hapi.endpoints.get_request_verification import router as request_verification_router  # noqa
 
 from hdx_hapi.endpoints.favicon import router as favicon_router  # noqa
 
@@ -74,6 +75,7 @@ app = FastAPI(
 )
 
 app.include_router(encoded_identifier_router)
+app.include_router(request_verification_router)
 app.include_router(favicon_router)
 app.include_router(operational_presence_router)
 app.include_router(funding_router)

--- a/tests/test_endpoints/test_endpoints_vs_encode_identifier.py
+++ b/tests/test_endpoints/test_endpoints_vs_encode_identifier.py
@@ -41,7 +41,7 @@ async def test_endpoints_vs_encode_identifier(event_loop, refresh_db, enable_hap
     for endpoint_router in ENDPOINT_ROUTER_LIST:
         async with AsyncClient(app=app, base_url='http://test') as ac:
             response = await ac.get(endpoint_router)
-        assert response.status_code == 400
+        assert response.status_code == 403
 
         async with AsyncClient(app=app, base_url='http://test', params=query_parameters) as ac:
             response = await ac.get(endpoint_router)

--- a/tests/test_endpoints/test_request_verification_endpoint.py
+++ b/tests/test_endpoints/test_request_verification_endpoint.py
@@ -1,0 +1,38 @@
+import pytest
+
+from httpx import AsyncClient
+from main import app
+
+
+ENDPOINT_ROUTER = '/api/v1/util/verify-request'
+
+APP_IDENTIFIER = 'cHl0ZXN0czpweXRlc3RzQGh1bWRhdGEub3Jn'
+URL_WITHOUT_APP_IDENTIFIER = 'http://localhost/api/v1/population-social/population?output_format=json&limit=10&offset=0'
+URL_WITH_APP_IDENTIFIER = (
+    'http://localhost/api/v1/population-social/population?output_format=json&'
+    f'app_identifier={APP_IDENTIFIER}&limit=10&offset=0'
+)
+
+
+@pytest.mark.asyncio
+async def test_verify_request(event_loop, refresh_db, enable_hapi_identifier_filtering):
+    status_code = await _perform_request({})
+    assert status_code == 403
+
+    headers = {'X-Original-URI': URL_WITHOUT_APP_IDENTIFIER}
+    status_code = await _perform_request(headers)
+    assert status_code == 403
+
+    headers = {'X-Original-URI': URL_WITHOUT_APP_IDENTIFIER, 'X-HDX-HAPI-APP-IDENTIFIER': APP_IDENTIFIER}
+    status_code = await _perform_request(headers)
+    assert status_code == 200
+
+    headers = {'X-Original-URI': URL_WITH_APP_IDENTIFIER}
+    status_code = await _perform_request(headers)
+    assert status_code == 200
+
+
+async def _perform_request(headers) -> int:
+    async with AsyncClient(app=app, base_url='http://test', headers=headers) as ac:
+        response = await ac.get(ENDPOINT_ROUTER)
+    return response.status_code


### PR DESCRIPTION
This is based on @teodorescuserban's idea. The problem that we're trying to solve is related to the nginx cache. When nginx was serving a request from the cache, the `app_identifier` was no longer checked because the request was not reaching HAPI.

Before responding to a request from cache, nginx will now first check with HAPI that the `app_identifier` provided in the request is correct.
This happens by nginx sending a request to `/api/util/verify-request` . The endpoint doesn't really do anything, but if it gets to return HTTP code 200 with an empty body then nginx knows it's allowed to serve the request from the cache.

The request will have the same HTTP headers as the original request received by nginx + it will contain an additional header `X-Original-URI` that will contain the URL of the original request.

With the added complexity, I had to refactor the app identifier middleware to be a bit more readable 