### PR TITLE
PR - Mixpanel tracking improvements

### DIFF
--- a/hdx_hapi/endpoints/middleware/app_identifier_middleware.py
+++ b/hdx_hapi/endpoints/middleware/app_identifier_middleware.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, EmailStr
 
 from hdx_hapi.config.config import get_config
 from hdx_hapi.endpoints.util.util import app_name_identifier_query, email_identifier_query
-from hdx_hapi.endpoints.middleware.util.util import _extract_path_identifier_and_query_params
+from hdx_hapi.endpoints.middleware.util.util import extract_path_identifier_and_query_params
 
 import base64
 import logging
@@ -47,7 +47,7 @@ async def app_identifier_middleware(request: Request, call_next):
         if is_nginx_verify_request:
             if not original_uri_from_nginx:
                 return JSONResponse(content={'error': 'Missing X-Original-URI'}, status_code=status.HTTP_403_FORBIDDEN)
-            path, app_identifier, _ = _extract_path_identifier_and_query_params(original_uri_from_nginx)
+            path, app_identifier, _ = extract_path_identifier_and_query_params(original_uri_from_nginx)
         else:
             path = request.url.path
             app_identifier = request.query_params.get('app_identifier')

--- a/hdx_hapi/endpoints/middleware/util/util.py
+++ b/hdx_hapi/endpoints/middleware/util/util.py
@@ -89,7 +89,7 @@ async def send_mixpanel_event(event_name: str, distinct_id: str, event_data: dic
     _CONFIG.MIXPANEL.track(distinct_id, event_name, event_data)
 
 
-def _extract_path_identifier_and_query_params(original_url: str) -> Tuple[str, Optional[str]]:
+def extract_path_identifier_and_query_params(original_url: str) -> Tuple[str, Optional[str]]:
     """
     Extract the path, app_identifier and query parameters from the Nginx header.
     Args:
@@ -113,8 +113,7 @@ def _parse_fastapi_request(request: Request) -> Tuple[str, List[str], str, str, 
         request: The FastAPI request object
 
     Returns:
-        Tuple containing:
-        app_identifier, endpoint, query_params_keys, output_format, admin_level, email_address, and current_url
+        Tuple containing endpoint, query_params_keys, output_format, admin_level and current_url
     """
     app_identifier = request.query_params.get('app_identifier', '')
     endpoint = request.url.path
@@ -136,7 +135,7 @@ def _parse_fastapi_request(request: Request) -> Tuple[str, List[str], str, str, 
 
 def _parse_nginx_header(request: Request) -> Tuple[str, List[str], str, str, str]:
     """
-    Parse the nginx "X-Original-URI" header to extract data needed for analytics.
+    Parse nginx headers to extract data needed for analytics.
 
     Args:
         request: The FastAPI request object.
@@ -145,7 +144,7 @@ def _parse_nginx_header(request: Request) -> Tuple[str, List[str], str, str, str
         Tuple containing endpoint, query_params_keys, output_format, admin_level and current_url
     """
     original_uri_from_nginx = request.headers.get('X-Original-URI')
-    endpoint, app_identifier, query_params = _extract_path_identifier_and_query_params(original_uri_from_nginx)
+    endpoint, app_identifier, query_params = extract_path_identifier_and_query_params(original_uri_from_nginx)
 
     query_params_keys = list(query_params.keys())
     output_format = query_params.get('output_format', [''])[0]

--- a/hdx_hapi/endpoints/middleware/util/util.py
+++ b/hdx_hapi/endpoints/middleware/util/util.py
@@ -2,6 +2,8 @@ import logging
 import hashlib
 import time
 import ua_parser.user_agent_parser as useragent
+from typing import Optional, Tuple, List
+from urllib.parse import parse_qs, urlparse, unquote
 from fastapi import Request, Response
 
 from hdx_hapi.config.config import get_config
@@ -13,31 +15,29 @@ _CONFIG = get_config()
 
 
 async def track_api_call(request: Request, response: Response):
-    current_url = str(request.url)
-    endpoint = request.url.path
-    query_params = list(request.query_params.keys())
-    output_format = request.query_params.get('output_format', '')
-    admin_level = request.query_params.get('admin_level', '')
+    is_nginx_verify_request = getattr(request.state, 'is_nginx_verify_request', False)
+
+    if is_nginx_verify_request:
+        endpoint, query_params_keys, output_format, admin_level, current_url = _parse_nginx_header(request)
+    else:
+        endpoint, query_params_keys, output_format, admin_level, current_url = _parse_fastapi_request(request)
 
     app_name = getattr(request.state, 'app_name', None)
     user_agent_string = request.headers.get('user-agent', '')
-    ip_address = request.headers.get('HTTP_X_REAL_IP', '')
-
+    ip_address = request.headers.get('x-forwarded-for', '')
     response_code = response.status_code
 
     distinct_id = HashCodeGenerator({'ip': ip_address, 'ua': user_agent_string}).compute_hash()
     event_time = time.time()
 
-    ua_dict = useragent.Parse(user_agent_string)
-    ua_os = ua_dict.get('os', {}).get('family')
-    ua_browser = ua_dict.get('user_agent', {}).get('family')
-    ua_browser_version = ua_dict.get('user_agent', {}).get('major')
+    ua_os, ua_browser, ua_browser_version = _parse_user_agent(user_agent_string)
 
     mixpanel_dict = {
         'endpoint name': endpoint,
-        'query params': query_params,
+        'query params': query_params_keys,
         'time': event_time,
         'app name': app_name,
+        'identifier verification': is_nginx_verify_request,
         'output format': output_format,
         'admin level': admin_level,
         'server side': True,
@@ -49,24 +49,30 @@ async def track_api_call(request: Request, response: Response):
         '$browser_version': ua_browser_version,
         '$current_url': current_url,
     }
-    await send_mixpanel_event('api call', distinct_id, mixpanel_dict)
+    await send_mixpanel_event('hapi api call', distinct_id, mixpanel_dict)
 
 
 async def track_page_view(request: Request, response: Response):
-    current_url = str(request.url)
+    is_nginx_verify_request = getattr(request.state, 'is_nginx_verify_request', False)
+
+    if is_nginx_verify_request:
+        _, _, _, _, current_url = _parse_nginx_header(request)
+    else:
+        _, _, _, _, current_url = _parse_fastapi_request(request)
+
     user_agent_string = request.headers.get('user-agent', '')
-    ip_address = request.headers.get('HTTP_X_REAL_IP', '')
+    ip_address = request.headers.get('x-forwarded-for', '')
     response_code = response.status_code
+
     distinct_id = HashCodeGenerator({'ip': ip_address, 'ua': user_agent_string}).compute_hash()
     event_time = time.time()
-    ua_dict = useragent.Parse(user_agent_string)
-    ua_os = ua_dict.get('os', {}).get('family')
-    ua_browser = ua_dict.get('user_agent', {}).get('family')
-    ua_browser_version = ua_dict.get('user_agent', {}).get('major')
+
+    ua_os, ua_browser, ua_browser_version = _parse_user_agent(user_agent_string)
 
     page_view_dict = {
-        'page title': 'HAPI - OpenAPI Docs',
+        'page title': 'HDX HAPI - OpenAPI Docs',
         'time': event_time,
+        'identifier verification': is_nginx_verify_request,
         'server side': True,
         'response code': response_code,
         'user agent': user_agent_string,
@@ -76,11 +82,103 @@ async def track_page_view(request: Request, response: Response):
         '$browser_version': ua_browser_version,
         '$current_url': current_url,
     }
-    await send_mixpanel_event('page view', distinct_id, page_view_dict)
+    await send_mixpanel_event('hapi openapi docs view', distinct_id, page_view_dict)
 
 
 async def send_mixpanel_event(event_name: str, distinct_id: str, event_data: dict):
     _CONFIG.MIXPANEL.track(distinct_id, event_name, event_data)
+
+
+def _extract_path_identifier_and_query_params(original_url: str) -> Tuple[str, Optional[str]]:
+    """
+    Extract the path, app_identifier and query parameters from the Nginx header.
+    Args:
+        original_url: The original URL from the Nginx header
+    Returns:
+        Tuple of path, app_identifier and query parameters
+    """
+
+    parsed_url = urlparse(original_url)
+    path = parsed_url.path
+    query_params = parse_qs(parsed_url.query)
+    app_identifier = query_params.get('app_identifier', [None])[0]
+    return path, app_identifier, query_params
+
+
+def _parse_fastapi_request(request: Request) -> Tuple[str, List[str], str, str, str]:
+    """
+    Parse the FastAPI request to extract data needed for analytics.
+
+    Args:
+        request: The FastAPI request object
+
+    Returns:
+        Tuple containing app_identifier, endpoint, query_params_keys, output_format, admin_level, email_address, and current_url
+    """
+    app_identifier = request.query_params.get('app_identifier', '')
+    endpoint = request.url.path
+
+    query_params_keys = list(request.query_params.keys())
+    output_format = request.query_params.get('output_format', '')
+    admin_level = request.query_params.get('admin_level', '')
+    email_address = request.query_params.get('email', '')
+
+    current_url = unquote(str(request.url))
+
+    if app_identifier:
+        current_url = current_url.replace(app_identifier, 'unavailable')
+    if email_address:
+        current_url = current_url.replace(email_address, 'unavailable')
+
+    return endpoint, query_params_keys, output_format, admin_level, current_url
+
+
+def _parse_nginx_header(request: Request) -> Tuple[str, List[str], str, str, str]:
+    """
+    Parse the nginx "X-Original-URI" header to extract data needed for analytics.
+
+    Args:
+        request: The FastAPI request object.
+
+    Returns:
+        Tuple containing endpoint, query_params_keys, output_format, admin_level and current_url
+    """
+    original_uri_from_nginx = request.headers.get('X-Original-URI')
+    endpoint, app_identifier, query_params = _extract_path_identifier_and_query_params(original_uri_from_nginx)
+
+    query_params_keys = list(query_params.keys())
+    output_format = query_params.get('output_format', [''])[0]
+    admin_level = query_params.get('admin_level', [''])[0]
+    email_address = query_params.get('email', [''])[0]
+
+    protocol = request.headers.get('x-forwarded-proto', '')
+    host = request.headers.get('x-forwarded-host', '')
+    current_url = unquote(f"{protocol}://{host}{original_uri_from_nginx}")
+
+    if app_identifier:
+        current_url = current_url.replace(app_identifier, 'unavailable')
+    if email_address:
+        current_url = current_url.replace(email_address, 'unavailable')
+
+    return endpoint, query_params_keys, output_format, admin_level, current_url
+
+
+def _parse_user_agent(user_agent: str) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    """
+    Parse the user agent string to extract the operating system, browser, and browser version.
+
+    Args:
+        user_agent: The user agent string to be parsed
+
+    Returns:
+        A tuple containing the operating system, browser, and browser version
+    """
+    ua_dict = useragent.Parse(user_agent)
+    ua_os = ua_dict.get('os', {}).get('family')
+    ua_browser = ua_dict.get('user_agent', {}).get('family')
+    ua_browser_version = ua_dict.get('user_agent', {}).get('major')
+
+    return ua_os, ua_browser, ua_browser_version
 
 
 class HashCodeGenerator(object):

--- a/hdx_hapi/endpoints/middleware/util/util.py
+++ b/hdx_hapi/endpoints/middleware/util/util.py
@@ -113,7 +113,8 @@ def _parse_fastapi_request(request: Request) -> Tuple[str, List[str], str, str, 
         request: The FastAPI request object
 
     Returns:
-        Tuple containing app_identifier, endpoint, query_params_keys, output_format, admin_level, email_address, and current_url
+        Tuple containing:
+        app_identifier, endpoint, query_params_keys, output_format, admin_level, email_address, and current_url
     """
     app_identifier = request.query_params.get('app_identifier', '')
     endpoint = request.url.path
@@ -153,7 +154,7 @@ def _parse_nginx_header(request: Request) -> Tuple[str, List[str], str, str, str
 
     protocol = request.headers.get('x-forwarded-proto', '')
     host = request.headers.get('x-forwarded-host', '')
-    current_url = unquote(f"{protocol}://{host}{original_uri_from_nginx}")
+    current_url = unquote(f'{protocol}://{host}{original_uri_from_nginx}')
 
     if app_identifier:
         current_url = current_url.replace(app_identifier, 'unavailable')

--- a/tests/test_analytics/test_api_call_tracking.py
+++ b/tests/test_analytics/test_api_call_tracking.py
@@ -25,7 +25,7 @@ async def test_tracking_endpoint_success():
         async with AsyncClient(app=app, base_url=TEST_BASE_URL) as ac:
             headers = {
                 'User-Agent': TEST_USER_AGENT,
-                'HTTP_X_REAL_IP': '127.0.0.1',
+                'x-forwarded-for': '127.0.0.1',
             }
             params = {'admin_level': '1', 'output_format': 'json'}
             response = await ac.get(ENDPOINT, params=params, headers=headers)
@@ -38,6 +38,7 @@ async def test_tracking_endpoint_success():
             'query params': ['admin_level', 'output_format'],
             'time': pytest.approx(time.time()),
             'app name': None,
+            'identifier verification': False,
             'output format': 'json',
             'admin level': '1',
             'server side': True,
@@ -51,7 +52,7 @@ async def test_tracking_endpoint_success():
         }
 
         # Check parameters match the expected ones
-        send_mixpanel_event_patch.assert_called_once_with('api call', '123456', expected_mixpanel_dict)
+        send_mixpanel_event_patch.assert_called_once_with('hapi api call', '123456', expected_mixpanel_dict)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- parsed headers coming to the new endpoint handling "app_identifier" validation to send Mixpanel events
- renamed both events `api call` -> `hapi api call` and `page view` -> `hapi openapi docs view`
- added a new property (`identifier verification`) to indicate if the event is coming from the verification endpoint
- updated the nginx header used for retrieving the real user IP address (`x-forwarded-for`)
- replaced `app_identifier` and `email` param values with "**unavailable**"