### PR TITLE
HDX-9910 remove openapi_examples

### DIFF
--- a/hdx_hapi/endpoints/get_currency.py
+++ b/hdx_hapi/endpoints/get_currency.py
@@ -37,7 +37,7 @@ async def get_currencies(
     common_parameters: Annotated[CommonEndpointParams, Depends(common_endpoint_parameters)],
     db: AsyncSession = Depends(get_db),
     code: Annotated[
-        str, Query(max_length=32, description=f'{DOC_CURRENCY_CODE}', openapi_examples={'usd': {'value': 'usd'}})
+        str, Query(max_length=32, description=f'{DOC_CURRENCY_CODE}')
     ] = None,
     output_format: OutputFormat = OutputFormat.JSON,
 ):

--- a/hdx_hapi/endpoints/get_hdx_metadata.py
+++ b/hdx_hapi/endpoints/get_hdx_metadata.py
@@ -95,11 +95,11 @@ async def get_resources(
     format: Annotated[str, Query(max_length=32, description=f'{DOC_HDX_RESOURCE_FORMAT}')] = None,
     update_date_min: Annotated[
         NaiveDatetime | date,
-        Query(description=f'{DOC_UPDATE_DATE_MIN}', openapi_examples={'2020-01-01': {'value': '2020-01-01'}}),
+        Query(description=f'{DOC_UPDATE_DATE_MIN}'),
     ] = None,
     update_date_max: Annotated[
         NaiveDatetime | date,
-        Query(description=f'{DOC_UPDATE_DATE_MAX}', openapi_examples={'2024-12-31': {'value': '2024-12-31'}}),
+        Query(description=f'{DOC_UPDATE_DATE_MAX}'),
     ] = None,
     is_hxl: Annotated[bool, Query(description=f'{DOC_HDX_RESOURCE_HXL}')] = None,
     dataset_hdx_id: Annotated[

--- a/hdx_hapi/endpoints/get_humanitarian_response.py
+++ b/hdx_hapi/endpoints/get_humanitarian_response.py
@@ -48,18 +48,13 @@ async def get_orgs(
     common_parameters: Annotated[CommonEndpointParams, Depends(common_endpoint_parameters)],
     db: AsyncSession = Depends(get_db),
     acronym: Annotated[
-        str, Query(max_length=32, description=f'{DOC_ORG_ACRONYM}', openapi_examples={'unhcr': {'value': 'unhcr'}})
+        str, Query(max_length=32, description=f'{DOC_ORG_ACRONYM}')
     ] = None,
     name: Annotated[
         str,
         Query(
             max_length=512,
             description=f'{DOC_ORG_NAME}',
-            openapi_examples={
-                'United Nations High Commissioner for Refugees': {
-                    'value': 'United Nations High Commissioner for Refugees'
-                }
-            },
         ),
     ] = None,
     org_type_code: Annotated[str, Query(max_length=32, description=f'{DOC_ORG_TYPE_CODE}')] = None,
@@ -95,12 +90,12 @@ async def get_org_types(
     common_parameters: Annotated[CommonEndpointParams, Depends(common_endpoint_parameters)],
     db: AsyncSession = Depends(get_db),
     code: Annotated[
-        str, Query(max_length=32, description=f'{DOC_ORG_TYPE_CODE}', openapi_examples={'433': {'value': '433'}})
+        str, Query(max_length=32, description=f'{DOC_ORG_TYPE_CODE}')
     ] = None,
     description: Annotated[
         str,
         Query(
-            max_length=512, description=f'{DOC_ORG_TYPE_DESCRIPTION}', openapi_examples={'Donor': {'value': 'Donor'}}
+            max_length=512, description=f'{DOC_ORG_TYPE_DESCRIPTION}'
         ),
     ] = None,
     output_format: OutputFormat = OutputFormat.JSON,
@@ -127,10 +122,10 @@ async def get_sectors(
     common_parameters: Annotated[CommonEndpointParams, Depends(common_endpoint_parameters)],
     db: AsyncSession = Depends(get_db),
     code: Annotated[
-        str, Query(max_length=32, description=f'{DOC_SECTOR_CODE}', openapi_examples={'hea': {'value': 'hea'}})
+        str, Query(max_length=32, description=f'{DOC_SECTOR_CODE}')
     ] = None,
     name: Annotated[
-        str, Query(max_length=512, description=f'{DOC_SECTOR_NAME}', openapi_examples={'Health': {'value': 'Health'}})
+        str, Query(max_length=512, description=f'{DOC_SECTOR_NAME}')
     ] = None,
     output_format: OutputFormat = OutputFormat.JSON,
 ):


### PR DESCRIPTION
removed OpenAPI examples from:

- `code` in the `currency` endpoint
- `acronym` and `name` in the `org` endpoint
- `code` and `description` in the `org-type` endpoint
- `update_date_min` and `update_date_max`  in the `resource` endpoint
- `code` and `name` in the `sector` endpoint