### PR TITLE
PR Bugfix/HDX-9952 field names in vat tables 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ ua-parser==0.18.0
 alembic~=1.12.00
 psycopg2~=2.9.7
 
--e git+https://github.com/OCHA-DAP/hapi-sqlalchemy-schema@bugfix/field-names-in-vat-tables#egg=hapi-schema
+-e git+https://github.com/OCHA-DAP/hapi-sqlalchemy-schema@v0.8.13#egg=hapi-schema

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,4 @@ ua-parser==0.18.0
 alembic~=1.12.00
 psycopg2~=2.9.7
 
--e git+https://github.com/OCHA-DAP/hapi-sqlalchemy-schema@v0.8.12#egg=hapi-schema
-
+-e git+https://github.com/OCHA-DAP/hapi-sqlalchemy-schema@bugfix/field-names-in-vat-tables#egg=hapi-schema


### PR DESCRIPTION
HDX-9952 using hapi schema 0.8.13

Fixes problem with VAT tables not having the renamed dataset/resource fields
https://github.com/OCHA-DAP/hapi-sqlalchemy-schema/pull/54/files
