### PR TITLE
HDX-9960 has_hrp and in_gho bugfix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ in_gho: Optional[bool] = None,
 ```
 And the relevant query added, for these boolean parameters it is easy:
 ```python
-if has_hrp is not None:is not None:
+if has_hrp is not None:
     query = query.where(LocationView.has_hrp == has_hrp)
 if in_gho is not None:
     query = query.where(LocationView.in_gho == in_gho)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,9 +102,9 @@ in_gho: Optional[bool] = None,
 ```
 And the relevant query added, for these boolean parameters it is easy:
 ```python
-if has_hrp:
+if has_hrp is not None:is not None:
     query = query.where(LocationView.has_hrp == has_hrp)
-if in_gho:
+if in_gho is not None:
     query = query.where(LocationView.in_gho == in_gho)
 ```
 Actually in this case we do not need to make this explicit conditional statements because the parameters we introduce here are in the `EntityWithLocationAdmin` class and are handled by `apply_location_admin_filter`.

--- a/hdx_hapi/db/dao/funding_view_dao.py
+++ b/hdx_hapi/db/dao/funding_view_dao.py
@@ -44,9 +44,9 @@ async def funding_view_list(
         query = case_insensitive_filter(query, FundingView.appeal_code, appeal_code)
     if appeal_type:
         query = case_insensitive_filter(query, FundingView.appeal_type, appeal_type)
-    if has_hrp:
+    if has_hrp is not None:
         query = query.where(FundingView.has_hrp == has_hrp)
-    if in_gho:
+    if in_gho is not None:
         query = query.where(FundingView.in_gho == in_gho)
 
     query = apply_reference_period_filter(query, ref_period_parameters, FundingView)

--- a/hdx_hapi/db/dao/location_view_dao.py
+++ b/hdx_hapi/db/dao/location_view_dao.py
@@ -21,7 +21,7 @@ async def locations_view_list(
     has_hrp: Optional[bool] = None,
     in_gho: Optional[bool] = None,
 ):
-    logger.info(f'orgs_view_list called with params: code={code}, name={name}')
+    logger.info(f'location_view_list called with params: code={code}, name={name}, has_hrp={has_hrp}, in_gho={in_gho}')
 
     query = select(LocationView)
     if id:
@@ -30,9 +30,9 @@ async def locations_view_list(
         query = case_insensitive_filter(query, LocationView.code, code)
     if name:
         query = query.where(LocationView.name.icontains(name))
-    if has_hrp:
+    if has_hrp is not None:
         query = query.where(LocationView.has_hrp == has_hrp)
-    if in_gho:
+    if in_gho is not None:
         query = query.where(LocationView.in_gho == in_gho)
 
     query = apply_reference_period_filter(query, ref_period_parameters, LocationView)

--- a/hdx_hapi/db/dao/national_risk_view_dao.py
+++ b/hdx_hapi/db/dao/national_risk_view_dao.py
@@ -53,9 +53,9 @@ async def national_risks_view_list(
     if coping_capacity_risk_max:
         query = query.where(NationalRiskView.coping_capacity_risk < coping_capacity_risk_max)
 
-    if has_hrp:
+    if has_hrp is not None:
         query = query.where(NationalRiskView.has_hrp == has_hrp)
-    if in_gho:
+    if in_gho is not None:
         query = query.where(NationalRiskView.in_gho == in_gho)
 
     # if sector_name:

--- a/hdx_hapi/db/dao/refugees_view_dao.py
+++ b/hdx_hapi/db/dao/refugees_view_dao.py
@@ -51,13 +51,13 @@ async def refugees_view_list(
         query = case_insensitive_filter(query, RefugeesView.asylum_location_code, asylum_location_code)
     if asylum_location_name:
         query = query.where(RefugeesView.asylum_location_name.icontains(asylum_location_name))
-    if origin_has_hrp:
+    if origin_has_hrp is not None:
         query = query.where(RefugeesView.origin_has_hrp == origin_has_hrp)
-    if origin_in_gho:
+    if origin_in_gho is not None:
         query = query.where(RefugeesView.origin_in_gho == origin_in_gho)
-    if asylum_has_hrp:
+    if asylum_has_hrp is not None:
         query = query.where(RefugeesView.asylum_has_hrp == asylum_has_hrp)
-    if asylum_in_gho:
+    if asylum_in_gho is not None:
         query = query.where(RefugeesView.asylum_in_gho == asylum_in_gho)
 
     query = apply_reference_period_filter(query, ref_period_parameters, RefugeesView)

--- a/hdx_hapi/db/dao/util/util.py
+++ b/hdx_hapi/db/dao/util/util.py
@@ -95,9 +95,9 @@ def apply_location_admin_filter(
         query = query.where(db_class.admin1_is_unspecified == admin1_is_unspecified)
     if admin2_is_unspecified is not None:
         query = query.where(db_class.admin2_is_unspecified == admin2_is_unspecified)
-    if has_hrp:
+    if has_hrp is not None:
         query = query.where(db_class.has_hrp == has_hrp)
-    if in_gho:
+    if in_gho is not None:
         query = query.where(db_class.in_gho == in_gho)
 
     return query


### PR DESCRIPTION
This PR fixes a bug in the implementation of HDX-9960, adding the `has_hrp` and `in_gho`. The issue was that when building the query conditions like:
`if has_hrp:`
were used. Since `has_hrp` and `in_gho` are boolean then this means that the query clause is skipped for values of both (`None`) as intended, but also `False` (not intended). So these conditions are replaced with:
`if has_hrp is not None:`
Testing for this on the API is best done on the location endpoint since that is the only one that has `has_hrp` and `in_gho` in the response. Locally, with the latest database the fixed API returns the following numbers of responses:

No filters			                249 rows
Has_hrp, in_gho both true	24 rows
Has_hrp, in_gho both false	178 rows - this one is returns 249 rows before the fix
False, true			        47 rows
True, false                        	0 rows

So adding a query `?has_hrp=false&in_gho=false` to the smoke tests would be diagnostic.
 