### PR TITLE
HDX-10068 Add ordering to queries to address duplicate row issues.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,7 @@
             "program": "main.py",
             "console": "integratedTerminal",
             "justMyCode": true,
+            "env":{"HAPI_USE_VAT": "false"}
         }
     ],
     

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,11 +20,15 @@ Then for each session the following needs to be run:
 cd docker
 docker-compose up -d
 cd ..
+./initialize_db.sh
 ./initialize_test_db.sh
-./restore_database.sh https://github.com/OCHA-DAP/hapi-pipelines/raw/db-export/database/hapi_db.pg_restore hapi
 ```
 
-
+Historically, when hapi used views in the database, a full copy of the hapi database could be populated using a commandline like:
+```shell
+./restore_database.sh https://github.com/OCHA-DAP/hapi-pipelines/raw/db-export/database/hapi_db.pg_restore hapi
+```
+Since August 2024 a View as Table (VAT) version of the database should be used. This is configured by setting the `HAPI_USE_VAT` environment variable to `"True"`, and then populating the database using the `hdx-hapi-write-app`.
 
 Tests can either be run from the Visual Code test runner or with:
 
@@ -40,7 +44,7 @@ A local copy of HDX HAPI can be run by importing a snapshot of the database usin
  ./restore_database.sh https://github.com/OCHA-DAP/hapi-pipelines/raw/db-export/database/hapi_db.pg_restore hapi
 ```
 
-The HDX HAPI application can then be launched using the `start` launch configuration in Visual Code, this serves the documentation at `http://localhost:8844/docs` and the API at `http://localhost:8844/api` in the host machine.
+The HDX HAPI application can then be launched using the `start` launch configuration in Visual Code, this serves the documentation at `http://localhost:8844/docs` and the API at `http://localhost:8844/api` in the host machine. It is best to use `Run->Run without debugging` to launch for performance reasons.
 
 The HDX HAPI database can be accessed locally with the following connection details: 
 

--- a/hdx_hapi/config/config.py
+++ b/hdx_hapi/config/config.py
@@ -71,7 +71,7 @@ def get_config() -> Config:
             ),
             HAPI_SERVER_URL=os.getenv('HAPI_SERVER_URL', None),
             HAPI_IDENTIFIER_FILTERING=os.getenv('HAPI_IDENTIFIER_FILTERING', 'True').lower() == 'true',
-            HAPI_USE_VAT=os.getenv('HAPI_USE_VAT', 'True').lower() == 'true',
+            HAPI_USE_VAT=os.getenv('HAPI_USE_VAT', 'False').lower() == 'true',
             MIXPANEL=Mixpanel(mixpanel_token) if mixpanel_token else None,
         )
 

--- a/hdx_hapi/config/config.py
+++ b/hdx_hapi/config/config.py
@@ -1,7 +1,9 @@
 import logging
 import os
 
+
 from dataclasses import dataclass
+from typing import Optional
 from mixpanel import Mixpanel
 
 from hdx_hapi.config.helper import create_pg_uri_from_env_without_protocol
@@ -28,11 +30,13 @@ class Config:
 
     HAPI_READTHEDOCS_OVERVIEW_URL: str
 
-    HAPI_SERVER_URL: str
+    HAPI_SERVER_URL: Optional[str]
 
     HAPI_IDENTIFIER_FILTERING: bool
 
-    MIXPANEL: Mixpanel
+    HAPI_USE_VAT: bool
+
+    MIXPANEL: Optional[Mixpanel]
 
 
 CONFIG = None
@@ -67,6 +71,7 @@ def get_config() -> Config:
             ),
             HAPI_SERVER_URL=os.getenv('HAPI_SERVER_URL', None),
             HAPI_IDENTIFIER_FILTERING=os.getenv('HAPI_IDENTIFIER_FILTERING', 'True').lower() == 'true',
+            HAPI_USE_VAT=os.getenv('HAPI_USE_VAT', 'True').lower() == 'true',
             MIXPANEL=Mixpanel(mixpanel_token) if mixpanel_token else None,
         )
 

--- a/hdx_hapi/db/dao/admin1_view_dao.py
+++ b/hdx_hapi/db/dao/admin1_view_dao.py
@@ -49,7 +49,6 @@ async def admin1_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, Admin1View)
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(Admin1View.location_code.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/admin1_view_dao.py
+++ b/hdx_hapi/db/dao/admin1_view_dao.py
@@ -49,6 +49,7 @@ async def admin1_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, Admin1View)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(Admin1View.id)
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/admin1_view_dao.py
+++ b/hdx_hapi/db/dao/admin1_view_dao.py
@@ -1,5 +1,7 @@
 import logging
 
+from typing import Optional
+
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
@@ -15,12 +17,12 @@ async def admin1_view_list(
     pagination_parameters: PaginationParams,
     ref_period_parameters: ReferencePeriodParameters,
     db: AsyncSession,
-    id: int = None,
-    location_ref: int = None,
-    code: str = None,
-    name: str = None,
-    location_code: str = None,
-    location_name: str = None,
+    id: Optional[int] = None,
+    location_ref: Optional[int] = None,
+    code: Optional[str] = None,
+    name: Optional[str] = None,
+    location_code: Optional[str] = None,
+    location_name: Optional[str] = None,
 ):
     logger.info(
         f'admin1_view_list called with params: code={code}, name={name}, '
@@ -47,6 +49,7 @@ async def admin1_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, Admin1View)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(Admin1View.location_code.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/admin2_view_dao.py
+++ b/hdx_hapi/db/dao/admin2_view_dao.py
@@ -56,7 +56,6 @@ async def admin2_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, Admin2View)
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(Admin2View.id.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/admin2_view_dao.py
+++ b/hdx_hapi/db/dao/admin2_view_dao.py
@@ -56,6 +56,7 @@ async def admin2_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, Admin2View)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(Admin2View.id)
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/admin2_view_dao.py
+++ b/hdx_hapi/db/dao/admin2_view_dao.py
@@ -56,7 +56,7 @@ async def admin2_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, Admin2View)
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(Admin2View.location_code.asc())
+    query = query.order_by(Admin2View.id.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/admin2_view_dao.py
+++ b/hdx_hapi/db/dao/admin2_view_dao.py
@@ -1,5 +1,5 @@
 import logging
-
+from typing import Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
@@ -15,15 +15,15 @@ async def admin2_view_list(
     pagination_parameters: PaginationParams,
     ref_period_parameters: ReferencePeriodParameters,
     db: AsyncSession,
-    id: int = None,
-    admin1_ref: int = None,
-    location_ref: int = None,
-    code: str = None,
-    name: str = None,
-    admin1_code: str = None,
-    admin1_name: str = None,
-    location_code: str = None,
-    location_name: str = None,
+    id: Optional[int] = None,
+    admin1_ref: Optional[int] = None,
+    location_ref: Optional[int] = None,
+    code: Optional[str] = None,
+    name: Optional[str] = None,
+    admin1_code: Optional[str] = None,
+    admin1_name: Optional[str] = None,
+    location_code: Optional[str] = None,
+    location_name: Optional[str] = None,
 ):
     logger.info(
         f'admin2_view_list called with params: code={code}, name={name}, admin1_code={admin1_code}, '
@@ -56,6 +56,7 @@ async def admin2_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, Admin2View)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(Admin2View.location_code.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/conflict_event_view_dao.py
+++ b/hdx_hapi/db/dao/conflict_event_view_dao.py
@@ -3,7 +3,7 @@ from typing import Optional, Sequence
 
 from hapi_schema.utils.enums import EventType
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+from sqlalchemy import select, column
 
 from hdx_hapi.db.models.views.vat_or_view import ConflictEventView
 from hdx_hapi.db.dao.util.util import (
@@ -61,7 +61,8 @@ async def conflict_event_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, ConflictEventView)
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(ConflictEventView.location_code.asc())
+
+    query = query.order_by(ConflictEventView.admin2_code.asc(), column('ctid').asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/conflict_event_view_dao.py
+++ b/hdx_hapi/db/dao/conflict_event_view_dao.py
@@ -61,6 +61,9 @@ async def conflict_event_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, ConflictEventView)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(
+        ConflictEventView.admin2_ref, ConflictEventView.event_type, ConflictEventView.reference_period_start
+    )
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/conflict_event_view_dao.py
+++ b/hdx_hapi/db/dao/conflict_event_view_dao.py
@@ -3,7 +3,7 @@ from typing import Optional, Sequence
 
 from hapi_schema.utils.enums import EventType
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, column
+from sqlalchemy import select
 
 from hdx_hapi.db.models.views.vat_or_view import ConflictEventView
 from hdx_hapi.db.dao.util.util import (

--- a/hdx_hapi/db/dao/conflict_event_view_dao.py
+++ b/hdx_hapi/db/dao/conflict_event_view_dao.py
@@ -62,8 +62,6 @@ async def conflict_event_view_list(
 
     query = apply_pagination(query, pagination_parameters)
 
-    query = query.order_by(ConflictEventView.admin2_code.asc(), column('ctid').asc())
-
     logger.debug(f'Executing SQL query: {query}')
 
     result = await db.execute(query)

--- a/hdx_hapi/db/dao/conflict_event_view_dao.py
+++ b/hdx_hapi/db/dao/conflict_event_view_dao.py
@@ -61,6 +61,7 @@ async def conflict_event_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, ConflictEventView)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(ConflictEventView.location_code.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/currency_view_dao.py
+++ b/hdx_hapi/db/dao/currency_view_dao.py
@@ -22,6 +22,7 @@ async def currencies_view_list(
         query = case_insensitive_filter(query, CurrencyView.code, code)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(CurrencyView.code.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/currency_view_dao.py
+++ b/hdx_hapi/db/dao/currency_view_dao.py
@@ -22,7 +22,6 @@ async def currencies_view_list(
         query = case_insensitive_filter(query, CurrencyView.code, code)
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(CurrencyView.code.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/currency_view_dao.py
+++ b/hdx_hapi/db/dao/currency_view_dao.py
@@ -22,6 +22,7 @@ async def currencies_view_list(
         query = case_insensitive_filter(query, CurrencyView.code, code)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(CurrencyView.code)
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/dataset_view_dao.py
+++ b/hdx_hapi/db/dao/dataset_view_dao.py
@@ -39,6 +39,7 @@ async def datasets_view_list(
         query = query.where(DatasetView.hdx_provider_name.icontains(hdx_provider_name))
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(DatasetView.dataset_hdx_stub.asc())
 
     logger.info(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/dataset_view_dao.py
+++ b/hdx_hapi/db/dao/dataset_view_dao.py
@@ -39,6 +39,7 @@ async def datasets_view_list(
         query = query.where(DatasetView.hdx_provider_name.icontains(hdx_provider_name))
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(DatasetView.dataset_hdx_id)
 
     logger.info(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/dataset_view_dao.py
+++ b/hdx_hapi/db/dao/dataset_view_dao.py
@@ -39,7 +39,6 @@ async def datasets_view_list(
         query = query.where(DatasetView.hdx_provider_name.icontains(hdx_provider_name))
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(DatasetView.dataset_hdx_stub.asc())
 
     logger.info(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/food_price_dao.py
+++ b/hdx_hapi/db/dao/food_price_dao.py
@@ -85,6 +85,7 @@ async def food_price_view_list(
     )
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(FoodPriceView.location_code.asc())
 
     result = await db.execute(query)
     food_prices = result.scalars().all()

--- a/hdx_hapi/db/dao/food_price_dao.py
+++ b/hdx_hapi/db/dao/food_price_dao.py
@@ -85,6 +85,14 @@ async def food_price_view_list(
     )
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(
+        FoodPriceView.market_code,
+        FoodPriceView.commodity_code,
+        FoodPriceView.unit,
+        FoodPriceView.price_flag,
+        FoodPriceView.price_type,
+        FoodPriceView.reference_period_start,
+    )
 
     result = await db.execute(query)
     food_prices = result.scalars().all()

--- a/hdx_hapi/db/dao/food_price_dao.py
+++ b/hdx_hapi/db/dao/food_price_dao.py
@@ -85,7 +85,6 @@ async def food_price_view_list(
     )
 
     query = apply_pagination(query, pagination_parameters)
-    # query = query.order_by(FoodPriceView.reference_period_start.asc(), FoodPriceView.admin2_ref.asc())
 
     result = await db.execute(query)
     food_prices = result.scalars().all()

--- a/hdx_hapi/db/dao/food_price_dao.py
+++ b/hdx_hapi/db/dao/food_price_dao.py
@@ -85,7 +85,7 @@ async def food_price_view_list(
     )
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(FoodPriceView.location_code.asc())
+    query = query.order_by(FoodPriceView.admin2_ref.asc())
 
     result = await db.execute(query)
     food_prices = result.scalars().all()

--- a/hdx_hapi/db/dao/food_price_dao.py
+++ b/hdx_hapi/db/dao/food_price_dao.py
@@ -85,7 +85,7 @@ async def food_price_view_list(
     )
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(FoodPriceView.admin2_ref.asc())
+    # query = query.order_by(FoodPriceView.reference_period_start.asc(), FoodPriceView.admin2_ref.asc())
 
     result = await db.execute(query)
     food_prices = result.scalars().all()

--- a/hdx_hapi/db/dao/food_security_view_dao.py
+++ b/hdx_hapi/db/dao/food_security_view_dao.py
@@ -61,7 +61,7 @@ async def food_security_view_list(
 
     query = apply_reference_period_filter(query, ref_period_parameters, FoodSecurityView)
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(FoodSecurityView.location_code.asc())
+    query = query.order_by(FoodSecurityView.admin2_ref.asc())
 
     result = await db.execute(query)
     food_security = result.scalars().all()

--- a/hdx_hapi/db/dao/food_security_view_dao.py
+++ b/hdx_hapi/db/dao/food_security_view_dao.py
@@ -61,6 +61,7 @@ async def food_security_view_list(
 
     query = apply_reference_period_filter(query, ref_period_parameters, FoodSecurityView)
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(FoodSecurityView.location_code.asc())
 
     result = await db.execute(query)
     food_security = result.scalars().all()

--- a/hdx_hapi/db/dao/food_security_view_dao.py
+++ b/hdx_hapi/db/dao/food_security_view_dao.py
@@ -61,6 +61,12 @@ async def food_security_view_list(
 
     query = apply_reference_period_filter(query, ref_period_parameters, FoodSecurityView)
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(
+        FoodSecurityView.admin2_ref,
+        FoodSecurityView.ipc_phase,
+        FoodSecurityView.ipc_type,
+        FoodSecurityView.reference_period_start,
+    )
 
     result = await db.execute(query)
     food_security = result.scalars().all()

--- a/hdx_hapi/db/dao/food_security_view_dao.py
+++ b/hdx_hapi/db/dao/food_security_view_dao.py
@@ -61,7 +61,6 @@ async def food_security_view_list(
 
     query = apply_reference_period_filter(query, ref_period_parameters, FoodSecurityView)
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(FoodSecurityView.admin2_ref.asc())
 
     result = await db.execute(query)
     food_security = result.scalars().all()

--- a/hdx_hapi/db/dao/funding_view_dao.py
+++ b/hdx_hapi/db/dao/funding_view_dao.py
@@ -52,6 +52,7 @@ async def funding_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, FundingView)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(FundingView.location_code.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/funding_view_dao.py
+++ b/hdx_hapi/db/dao/funding_view_dao.py
@@ -52,7 +52,6 @@ async def funding_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, FundingView)
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(FundingView.location_code.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/funding_view_dao.py
+++ b/hdx_hapi/db/dao/funding_view_dao.py
@@ -52,6 +52,7 @@ async def funding_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, FundingView)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(FundingView.appeal_code, FundingView.location_ref)
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/humanitarian_needs_view_dao.py
+++ b/hdx_hapi/db/dao/humanitarian_needs_view_dao.py
@@ -83,6 +83,7 @@ async def humanitarian_needs_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, HumanitarianNeedsView)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(HumanitarianNeedsView.location_code.asc())
 
     result = await db.execute(query)
     humanitarian_needs = result.scalars().all()

--- a/hdx_hapi/db/dao/humanitarian_needs_view_dao.py
+++ b/hdx_hapi/db/dao/humanitarian_needs_view_dao.py
@@ -83,7 +83,6 @@ async def humanitarian_needs_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, HumanitarianNeedsView)
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(HumanitarianNeedsView.location_code.asc())
 
     result = await db.execute(query)
     humanitarian_needs = result.scalars().all()

--- a/hdx_hapi/db/dao/humanitarian_needs_view_dao.py
+++ b/hdx_hapi/db/dao/humanitarian_needs_view_dao.py
@@ -83,6 +83,16 @@ async def humanitarian_needs_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, HumanitarianNeedsView)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(
+        HumanitarianNeedsView.admin2_ref,
+        HumanitarianNeedsView.gender,
+        HumanitarianNeedsView.age_range,
+        HumanitarianNeedsView.sector_code,
+        HumanitarianNeedsView.population_group,
+        HumanitarianNeedsView.population_status,
+        HumanitarianNeedsView.disabled_marker,
+        HumanitarianNeedsView.reference_period_start,
+    )
 
     result = await db.execute(query)
     humanitarian_needs = result.scalars().all()

--- a/hdx_hapi/db/dao/location_view_dao.py
+++ b/hdx_hapi/db/dao/location_view_dao.py
@@ -38,7 +38,6 @@ async def locations_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, LocationView)
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(LocationView.code.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/location_view_dao.py
+++ b/hdx_hapi/db/dao/location_view_dao.py
@@ -38,6 +38,7 @@ async def locations_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, LocationView)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(LocationView.code.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/location_view_dao.py
+++ b/hdx_hapi/db/dao/location_view_dao.py
@@ -38,6 +38,7 @@ async def locations_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, LocationView)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(LocationView.id)
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/national_risk_view_dao.py
+++ b/hdx_hapi/db/dao/national_risk_view_dao.py
@@ -68,6 +68,7 @@ async def national_risks_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, NationalRiskView)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(NationalRiskView.location_code.asc())
 
     result = await db.execute(query)
     national_risks = result.scalars().all()

--- a/hdx_hapi/db/dao/national_risk_view_dao.py
+++ b/hdx_hapi/db/dao/national_risk_view_dao.py
@@ -68,6 +68,7 @@ async def national_risks_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, NationalRiskView)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(NationalRiskView.location_ref, NationalRiskView.reference_period_start)
 
     result = await db.execute(query)
     national_risks = result.scalars().all()

--- a/hdx_hapi/db/dao/national_risk_view_dao.py
+++ b/hdx_hapi/db/dao/national_risk_view_dao.py
@@ -68,7 +68,6 @@ async def national_risks_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, NationalRiskView)
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(NationalRiskView.location_code.asc())
 
     result = await db.execute(query)
     national_risks = result.scalars().all()

--- a/hdx_hapi/db/dao/operational_presence_view_dao.py
+++ b/hdx_hapi/db/dao/operational_presence_view_dao.py
@@ -102,7 +102,7 @@ async def operational_presences_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, OperationalPresenceView)
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(OperationalPresenceView.location_code.asc())
+    query = query.order_by(OperationalPresenceView.admin2_ref.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/operational_presence_view_dao.py
+++ b/hdx_hapi/db/dao/operational_presence_view_dao.py
@@ -102,7 +102,6 @@ async def operational_presences_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, OperationalPresenceView)
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(OperationalPresenceView.admin2_ref.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/operational_presence_view_dao.py
+++ b/hdx_hapi/db/dao/operational_presence_view_dao.py
@@ -102,6 +102,13 @@ async def operational_presences_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, OperationalPresenceView)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(
+        OperationalPresenceView.admin2_ref,
+        OperationalPresenceView.org_acronym,
+        OperationalPresenceView.org_name,
+        OperationalPresenceView.sector_code,
+        OperationalPresenceView.reference_period_start,
+    )
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/operational_presence_view_dao.py
+++ b/hdx_hapi/db/dao/operational_presence_view_dao.py
@@ -102,6 +102,7 @@ async def operational_presences_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, OperationalPresenceView)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(OperationalPresenceView.location_code.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/org_type_view_dao.py
+++ b/hdx_hapi/db/dao/org_type_view_dao.py
@@ -26,6 +26,7 @@ async def org_types_view_list(
         query = query.where(OrgTypeView.description.icontains(description))
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(OrgTypeView.code)
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/org_type_view_dao.py
+++ b/hdx_hapi/db/dao/org_type_view_dao.py
@@ -26,7 +26,6 @@ async def org_types_view_list(
         query = query.where(OrgTypeView.description.icontains(description))
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(OrgTypeView.code.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/org_type_view_dao.py
+++ b/hdx_hapi/db/dao/org_type_view_dao.py
@@ -1,5 +1,6 @@
 import logging
 
+from typing import Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
@@ -13,8 +14,8 @@ logger = logging.getLogger(__name__)
 async def org_types_view_list(
     pagination_parameters: PaginationParams,
     db: AsyncSession,
-    code: str = None,
-    description: str = None,
+    code: Optional[str] = None,
+    description: Optional[str] = None,
 ):
     logger.info(f'org_types_view_list called with params: code={code}, description={description}')
 
@@ -25,6 +26,7 @@ async def org_types_view_list(
         query = query.where(OrgTypeView.description.icontains(description))
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(OrgTypeView.code.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/org_view_dao.py
+++ b/hdx_hapi/db/dao/org_view_dao.py
@@ -35,7 +35,7 @@ async def orgs_view_list(
         query = query.where(OrgView.org_type_description.icontains(org_type_description))
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(OrgView.acronym.asc())
+    query = query.order_by(OrgView.name.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/org_view_dao.py
+++ b/hdx_hapi/db/dao/org_view_dao.py
@@ -35,6 +35,7 @@ async def orgs_view_list(
         query = query.where(OrgView.org_type_description.icontains(org_type_description))
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(OrgView.acronym, OrgView.name)
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/org_view_dao.py
+++ b/hdx_hapi/db/dao/org_view_dao.py
@@ -35,7 +35,6 @@ async def orgs_view_list(
         query = query.where(OrgView.org_type_description.icontains(org_type_description))
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(OrgView.name.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/org_view_dao.py
+++ b/hdx_hapi/db/dao/org_view_dao.py
@@ -1,5 +1,6 @@
 import logging
 
+from typing import Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
@@ -13,10 +14,10 @@ logger = logging.getLogger(__name__)
 async def orgs_view_list(
     pagination_parameters: PaginationParams,
     db: AsyncSession,
-    acronym: str = None,
-    name: str = None,
-    org_type_code: str = None,
-    org_type_description: str = None,
+    acronym: Optional[str] = None,
+    name: Optional[str] = None,
+    org_type_code: Optional[str] = None,
+    org_type_description: Optional[str] = None,
 ):
     logger.info(
         f'orgs_view_list called with params: acronym={acronym}, name={name}, org_type_code={org_type_code}, '
@@ -34,6 +35,7 @@ async def orgs_view_list(
         query = query.where(OrgView.org_type_description.icontains(org_type_description))
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(OrgView.acronym.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/population_view_dao.py
+++ b/hdx_hapi/db/dao/population_view_dao.py
@@ -80,6 +80,7 @@ async def populations_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, PopulationView)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(PopulationView.admin2_ref, PopulationView.gender, PopulationView.age_range)
 
     logger.info(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/population_view_dao.py
+++ b/hdx_hapi/db/dao/population_view_dao.py
@@ -80,7 +80,6 @@ async def populations_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, PopulationView)
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(PopulationView.admin2_ref.asc())
 
     logger.info(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/population_view_dao.py
+++ b/hdx_hapi/db/dao/population_view_dao.py
@@ -80,6 +80,8 @@ async def populations_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, PopulationView)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(PopulationView.location_code.asc())
+
     logger.info(f'Executing SQL query: {query}')
 
     result = await db.execute(query)

--- a/hdx_hapi/db/dao/population_view_dao.py
+++ b/hdx_hapi/db/dao/population_view_dao.py
@@ -80,7 +80,7 @@ async def populations_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, PopulationView)
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(PopulationView.location_code.asc())
+    query = query.order_by(PopulationView.admin2_ref.asc())
 
     logger.info(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/poverty_rate_dao.py
+++ b/hdx_hapi/db/dao/poverty_rate_dao.py
@@ -47,7 +47,6 @@ async def poverty_rates_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, PovertyRateView)
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(PovertyRateView.location_code.asc())
 
     result = await db.execute(query)
     poverty_rates = result.scalars().all()

--- a/hdx_hapi/db/dao/poverty_rate_dao.py
+++ b/hdx_hapi/db/dao/poverty_rate_dao.py
@@ -47,6 +47,9 @@ async def poverty_rates_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, PovertyRateView)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(
+        PovertyRateView.admin1_ref, PovertyRateView.admin1_name, PovertyRateView.reference_period_start
+    )
 
     result = await db.execute(query)
     poverty_rates = result.scalars().all()

--- a/hdx_hapi/db/dao/poverty_rate_dao.py
+++ b/hdx_hapi/db/dao/poverty_rate_dao.py
@@ -47,6 +47,7 @@ async def poverty_rates_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, PovertyRateView)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(PovertyRateView.location_code.asc())
 
     result = await db.execute(query)
     poverty_rates = result.scalars().all()

--- a/hdx_hapi/db/dao/refugees_view_dao.py
+++ b/hdx_hapi/db/dao/refugees_view_dao.py
@@ -63,6 +63,7 @@ async def refugees_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, RefugeesView)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(RefugeesView.origin_location_code.asc())
 
     result = await db.execute(query)
     refugees = result.scalars().all()

--- a/hdx_hapi/db/dao/refugees_view_dao.py
+++ b/hdx_hapi/db/dao/refugees_view_dao.py
@@ -63,7 +63,6 @@ async def refugees_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, RefugeesView)
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(RefugeesView.origin_location_code.asc())
 
     result = await db.execute(query)
     refugees = result.scalars().all()

--- a/hdx_hapi/db/dao/refugees_view_dao.py
+++ b/hdx_hapi/db/dao/refugees_view_dao.py
@@ -63,6 +63,14 @@ async def refugees_view_list(
     query = apply_reference_period_filter(query, ref_period_parameters, RefugeesView)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(
+        RefugeesView.origin_location_ref,
+        RefugeesView.asylum_location_ref,
+        RefugeesView.population_group,
+        RefugeesView.gender,
+        RefugeesView.age_range,
+        RefugeesView.reference_period_start,
+    )
 
     result = await db.execute(query)
     refugees = result.scalars().all()

--- a/hdx_hapi/db/dao/resource_view_dao.py
+++ b/hdx_hapi/db/dao/resource_view_dao.py
@@ -51,7 +51,6 @@ async def resources_view_list(
         query = query.where(ResourceView.dataset_hdx_provider_name == dataset_hdx_provider_name)
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(ResourceView.dataset_hdx_stub.asc())
 
     result = await db.execute(query)
     resources = result.scalars().all()

--- a/hdx_hapi/db/dao/resource_view_dao.py
+++ b/hdx_hapi/db/dao/resource_view_dao.py
@@ -51,6 +51,7 @@ async def resources_view_list(
         query = query.where(ResourceView.dataset_hdx_provider_name == dataset_hdx_provider_name)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(ResourceView.resource_hdx_id)
 
     result = await db.execute(query)
     resources = result.scalars().all()

--- a/hdx_hapi/db/dao/resource_view_dao.py
+++ b/hdx_hapi/db/dao/resource_view_dao.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
@@ -10,18 +11,18 @@ from hdx_hapi.endpoints.util.util import PaginationParams
 async def resources_view_list(
     pagination_parameters: PaginationParams,
     db: AsyncSession,
-    resource_hdx_id: str = None,
-    format: str = None,
-    update_date_min: datetime = None,
-    update_date_max: datetime = None,
-    is_hxl: bool = None,
-    hapi_updated_date_min: datetime = None,
-    hapi_updated_date_max: datetime = None,
-    dataset_hdx_title: str = None,
-    dataset_hdx_id: str = None,
-    dataset_hdx_stub: str = None,
-    dataset_hdx_provider_stub: str = None,
-    dataset_hdx_provider_name: str = None,
+    resource_hdx_id: Optional[str] = None,
+    format: Optional[str] = None,
+    update_date_min: Optional[datetime] = None,
+    update_date_max: Optional[datetime] = None,
+    is_hxl: Optional[bool] = None,
+    hapi_updated_date_min: Optional[datetime] = None,
+    hapi_updated_date_max: Optional[datetime] = None,
+    dataset_hdx_title: Optional[str] = None,
+    dataset_hdx_id: Optional[str] = None,
+    dataset_hdx_stub: Optional[str] = None,
+    dataset_hdx_provider_stub: Optional[str] = None,
+    dataset_hdx_provider_name: Optional[str] = None,
 ):
     query = select(ResourceView)
     if resource_hdx_id:
@@ -50,6 +51,7 @@ async def resources_view_list(
         query = query.where(ResourceView.dataset_hdx_provider_name == dataset_hdx_provider_name)
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(ResourceView.dataset_hdx_stub.asc())
 
     result = await db.execute(query)
     resources = result.scalars().all()

--- a/hdx_hapi/db/dao/sector_view_dao.py
+++ b/hdx_hapi/db/dao/sector_view_dao.py
@@ -27,7 +27,6 @@ async def sectors_view_list(
         query = query.where(SectorView.name.icontains(name))
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(SectorView.code.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/sector_view_dao.py
+++ b/hdx_hapi/db/dao/sector_view_dao.py
@@ -27,6 +27,7 @@ async def sectors_view_list(
         query = query.where(SectorView.name.icontains(name))
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(SectorView.code)
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/sector_view_dao.py
+++ b/hdx_hapi/db/dao/sector_view_dao.py
@@ -1,5 +1,6 @@
 import logging
 
+from typing import Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
@@ -14,8 +15,8 @@ logger = logging.getLogger(__name__)
 async def sectors_view_list(
     pagination_parameters: PaginationParams,
     db: AsyncSession,
-    code: str = None,
-    name: str = None,
+    code: Optional[str] = None,
+    name: Optional[str] = None,
 ):
     logger.info(f'sectors_view_list called with params: code={code}, name={name}')
 
@@ -26,6 +27,7 @@ async def sectors_view_list(
         query = query.where(SectorView.name.icontains(name))
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(SectorView.code.asc())
 
     logger.debug(f'Executing SQL query: {query}')
 

--- a/hdx_hapi/db/dao/util/util.py
+++ b/hdx_hapi/db/dao/util/util.py
@@ -1,5 +1,5 @@
 from typing import Optional, Protocol, Type
-from sqlalchemy import DateTime, Select, column
+from sqlalchemy import DateTime, Select
 from sqlalchemy.orm import Mapped
 
 from hdx_hapi.config.config import get_config

--- a/hdx_hapi/db/dao/util/util.py
+++ b/hdx_hapi/db/dao/util/util.py
@@ -16,16 +16,6 @@ def apply_pagination(query: Select, pagination_parameters: PaginationParams) -> 
     if not limit:
         limit = 1000
 
-    # limit and offset should be used with an order by clause. If we are running View as Table
-    # then we can always use the internal ctid column. However, if we are using views then ctid
-    # does not exist and the order of succesive offset/limit call returns is not guarenteed so
-    # duplicate rows can be introduced
-    # See HDX-10068
-    if CONFIG.HAPI_USE_VAT:
-        query = query.limit(limit).offset(offset).order_by(column('ctid').asc())
-    else:
-        # You're in danger
-        query = query.limit(limit).offset(offset)
     return query.limit(limit).offset(offset)
 
 

--- a/hdx_hapi/db/dao/wfp_commodity_view_dao.py
+++ b/hdx_hapi/db/dao/wfp_commodity_view_dao.py
@@ -32,6 +32,7 @@ async def wfp_commodity_view_list(
         query = query.where(WfpCommodityView.name.icontains(name))
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(WfpCommodityView.code.asc())
 
     result = await db.execute(query)
     wfp_commodities = result.scalars().all()

--- a/hdx_hapi/db/dao/wfp_commodity_view_dao.py
+++ b/hdx_hapi/db/dao/wfp_commodity_view_dao.py
@@ -32,7 +32,6 @@ async def wfp_commodity_view_list(
         query = query.where(WfpCommodityView.name.icontains(name))
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(WfpCommodityView.code.asc())
 
     result = await db.execute(query)
     wfp_commodities = result.scalars().all()

--- a/hdx_hapi/db/dao/wfp_commodity_view_dao.py
+++ b/hdx_hapi/db/dao/wfp_commodity_view_dao.py
@@ -32,6 +32,7 @@ async def wfp_commodity_view_list(
         query = query.where(WfpCommodityView.name.icontains(name))
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(WfpCommodityView.code)
 
     result = await db.execute(query)
     wfp_commodities = result.scalars().all()

--- a/hdx_hapi/db/dao/wfp_market_view_dao.py
+++ b/hdx_hapi/db/dao/wfp_market_view_dao.py
@@ -61,6 +61,7 @@ async def wfp_market_view_list(
     )
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(WfpMarketView.location_code.asc())
 
     result = await db.execute(query)
     wfp_markets = result.scalars().all()

--- a/hdx_hapi/db/dao/wfp_market_view_dao.py
+++ b/hdx_hapi/db/dao/wfp_market_view_dao.py
@@ -61,7 +61,6 @@ async def wfp_market_view_list(
     )
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(WfpMarketView.code.asc())
 
     result = await db.execute(query)
     wfp_markets = result.scalars().all()

--- a/hdx_hapi/db/dao/wfp_market_view_dao.py
+++ b/hdx_hapi/db/dao/wfp_market_view_dao.py
@@ -61,7 +61,7 @@ async def wfp_market_view_list(
     )
 
     query = apply_pagination(query, pagination_parameters)
-    query = query.order_by(WfpMarketView.location_code.asc())
+    query = query.order_by(WfpMarketView.code.asc())
 
     result = await db.execute(query)
     wfp_markets = result.scalars().all()

--- a/hdx_hapi/db/dao/wfp_market_view_dao.py
+++ b/hdx_hapi/db/dao/wfp_market_view_dao.py
@@ -61,6 +61,7 @@ async def wfp_market_view_list(
     )
 
     query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(WfpMarketView.code)
 
     result = await db.execute(query)
     wfp_markets = result.scalars().all()

--- a/initialize_db.sh
+++ b/initialize_db.sh
@@ -15,6 +15,7 @@ $DCOMPOSE exec -T db psql -U postgres -c "grant all privileges on database $DB_N
 
 $DCOMPOSE exec -T db psql -U postgres $DB_NAME -c "GRANT USAGE, CREATE ON SCHEMA public TO $DB_USER;"
 $DCOMPOSE exec -T db psql -U postgres $DB_NAME -c "GRANT ALL ON ALL TABLES IN SCHEMA public TO $DB_USER;"
+$DCOMPOSE exec -T db psql -U postgres $DB_NAME -c "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO $DB_USER;"
 
 # DCOMPOSE exec -T hwa sh -c "alembic -x sqlalchemy.url=postgresql+psycopg2://$DB_USER:$DB_PASS@$DB_HOST:$DB_PORT/$DB_NAME upgrade $ALEMBIC_COMMIT"
 


### PR DESCRIPTION
HDX-10068 identified that for certain paged queries duplicate rows were found in the compiled results.

This PR now deals with the issue by using `order_by` clauses utilising the primary key columns of each table, this will work for both view and views as tables versions of the code and should return data in a consistent and "natural" order (i.e. one that makes sense to a user). Performance measured by time taken to run smoke tests locally based on views seems to be comparable to the version without `order_by`.

An early version of this PR used the `ctid` column for ordering, described below:

This PR addresses the issue by applying an `order_by` clause in the `apply_pagination` function. It uses the system column `ctid` for ordering since this is universally available in tables. This means that the database must be used in View as Table mode which is set using the `HAPI_USE_VAT` environment variables. Code is written such that the default is "False" which allows tests to run under the old views mode. 

The production database should now be populated with the `hdx-hapi-write-app` rather than the `restore_database` shell script as a result of the switch to "Views as Tables".

Some type-hinting is added to the query code files, in particular the `Optional` hint is applied where query parameters are optional and default to None.