### PR TITLE
HDXDSYS-1013 update food security for IPC and p-coding

### DIFF
--- a/docs/data_usage_guides/food_security_and_nutrition.md
+++ b/docs/data_usage_guides/food_security_and_nutrition.md
@@ -27,12 +27,12 @@ For available query parameters, please see the
 
 ### Transformations applied
 
-* We have p-coded the source data by taking the admin 1 and 2 names, and using
-  the algorithm provided by
-  [`hdx-python-country`](https://hdx-python-country.readthedocs.io/en/latest/)
+* We have p-coded the source data by taking the admin 1 and 2 names,
+  and applying the algorithm from
+  [`hdx-python-country`](https://hdx-python-country.readthedocs.io/en/latest/),
   which uses phonetic name matching and manual overrides
-* Any unmatched p-codes are not included in HDX HAPI. In a future version we
-  plan on keeping rows and including the provider admin names.
+* Any unmatched p-codes are not included in HDX HAPI; in a future version we
+  plan on retaining these rows and including the provider admin names
 
 ### Usage Notes
 

--- a/docs/data_usage_guides/food_security_and_nutrition.md
+++ b/docs/data_usage_guides/food_security_and_nutrition.md
@@ -27,16 +27,12 @@ For available query parameters, please see the
 
 ### Transformations applied
 
-* The table has been reshaped from wide to long: the population and individual
-  IPC phase columns have been cast to a combination of `ipc_phase` and
-  `population_in_phase`
-* The IPC fraction is computed in the HDX HAPI API pipeline, by dividing the
-  population in that phase by the total population (`ipc_phase`="all").
-* The reference period is computed from the “reference_label” and
-  “reference_year” columns in the original data. In the case of a projection,
-  it captures date range that the projection covers, not when the projection
-  was made
-* In the `ipc_type` column, “projected” is converted to “first projection”
+* We have p-coded the source data by taking the admin 1 and 2 names, and using
+  the algorithm provided by
+  [`hdx-python-country`](https://hdx-python-country.readthedocs.io/en/latest/)
+  which uses phonetic name matching and manual overrides
+* Any unmatched p-codes are not included in HDX HAPI. In a future version we
+  plan on keeping rows and including the provider admin names.
 
 ### Usage Notes
 

--- a/docs/data_usage_guides/food_security_and_nutrition.md
+++ b/docs/data_usage_guides/food_security_and_nutrition.md
@@ -8,11 +8,6 @@ The [IPC Acute Food Insecurity (IPC AFI) classification](https://www.ipcinfo.org
 provides strategically relevant information to decision makers that focuses on
 short-term objectives to prevent, mitigate or decrease severe food insecurity.
 
-The Beta release of HDX HAPI only contains data from the
-[Cadre Harmonisé](https://www.cadreharmonise.org/en_GB) (CH),
-as it is p-coded and uses the IPC classification system. In
-a future release we will p-code and expand coverage to other IPC datasets.
-
 ### Summary
 
 {{ read_yaml('data_usage_guides/subcategory_details/food_security_details.yaml') }}
@@ -31,7 +26,7 @@ For available query parameters, please see the
   and applying the algorithm from
   [`hdx-python-country`](https://hdx-python-country.readthedocs.io/en/latest/),
   which uses phonetic name matching and manual overrides
-* Any unmatched p-codes are not included in HDX HAPI; in a future version we
+* Any unmatched p-codes are not included in HDX HAPI. In a future version we
   plan on retaining these rows and including the provider admin names
 
 ### Usage Notes

--- a/docs/data_usage_guides/subcategory_details/food_security_details.yaml
+++ b/docs/data_usage_guides/subcategory_details/food_security_details.yaml
@@ -1,12 +1,13 @@
 - Attribute: Data provider
-  Details: Food Security and Nutrition Working Group, West and Central Africa
+  Details: >
+    [Integrated Food Security Phase Classification (IPC)](https://www.ipcinfo.org/)
 - Attribute: Dataset
   Details: >
-    [West & Central Africa Food Security Data - Cadre Harmonise (CH) and Integrated Food Security Phase Classification (IPC) dataset](https://data.humdata.org/dataset/cadre-harmonise)
+    [Global: Acute Food Insecurity Country Data](https://data.humdata.org/dataset/global-acute-food-insecurity-country-data)
 - Attribute: Time series
   Details: Yes, with projections
 - Attribute: Update frequency
-  Details: Annually
+  Details: As needed
 - Attribute: Related tables
   Details: >
     [`IPCPhase`](enums.md#ipc-phase), [`IPCType`](enums.md#ipc-type)


### PR DESCRIPTION
Under the food security sub-category, Mike has swapped out the Cadre Harmonisé data for IPC and p-coded it, here I've  updated the RTD to reflect this change