### PR TITLE
HDX-10120 Bump hapi-sqlalchemy-schema version to 0.8.15 for new date type annotations and for compatibility with the data availability branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ ua-parser==0.18.0
 alembic~=1.12.00
 psycopg2~=2.9.7
 
--e git+https://github.com/OCHA-DAP/hapi-sqlalchemy-schema@v0.8.15#egg=hapi-schema
+-e git+https://github.com/OCHA-DAP/hapi-sqlalchemy-schema@v0.8.16#egg=hapi-schema

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ ua-parser==0.18.0
 alembic~=1.12.00
 psycopg2~=2.9.7
 
--e git+https://github.com/OCHA-DAP/hapi-sqlalchemy-schema@v0.8.14#egg=hapi-schema
+-e git+https://github.com/OCHA-DAP/hapi-sqlalchemy-schema@v0.8.15#egg=hapi-schema


### PR DESCRIPTION
This PR just bumps the version of `hapi-sqlalchemy-schema` to 0.8.15 which contains the new type annotations.

The tests all pass which exercises the "views" version of the app. The smoke tests pass against a "View as Table" version of HAPI