### PR TITLE
HDX-9974 Add data availability endpoint

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,7 +24,6 @@ jobs:
 
       - name: Setup database
         run: |
-          ./initialize_db.sh 
           ./initialize_test_db.sh
         env:
           DCOMPOSE: "docker compose"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,8 @@ jobs:
           docker compose exec -T hapi sh -c "pip install --upgrade -r dev-requirements.txt"
 
       - name: Setup database
-        run: | 
+        run: |
+          ./initialize_db.sh 
           ./initialize_test_db.sh
         env:
           DCOMPOSE: "docker compose"

--- a/hdx_hapi/db/dao/availability_view_dao.py
+++ b/hdx_hapi/db/dao/availability_view_dao.py
@@ -1,0 +1,72 @@
+import datetime
+import logging
+from typing import Optional
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from hdx_hapi.db.models.views.vat_or_view import AvailabilityView
+from hdx_hapi.db.dao.util.util import apply_pagination, case_insensitive_filter
+from hdx_hapi.endpoints.util.util import PaginationParams
+
+logger = logging.getLogger(__name__)
+
+
+async def availability_view_list(
+    pagination_parameters: PaginationParams,
+    db: AsyncSession,
+    category: Optional[str] = None,
+    subcategory: Optional[str] = None,
+    location_name: Optional[str] = None,
+    location_code: Optional[str] = None,
+    admin1_name: Optional[str] = None,
+    admin1_code: Optional[str] = None,
+    admin2_name: Optional[str] = None,
+    admin2_code: Optional[str] = None,
+    hapi_update_date_min: Optional[datetime.datetime] = None,
+    hapi_update_date_max: Optional[datetime.datetime] = None,
+):
+    logger.info(f'availability_view_list called with params: {locals()}')
+
+    query = select(AvailabilityView)
+    if category:
+        query = case_insensitive_filter(query, AvailabilityView.category, category)
+    if subcategory:
+        query = case_insensitive_filter(query, AvailabilityView.subcategory, subcategory)
+
+    if location_code:
+        query = case_insensitive_filter(query, AvailabilityView.location_code, location_code)
+    if location_name:
+        query = query.where(AvailabilityView.location_name.icontains(location_name))
+    if admin1_code:
+        query = case_insensitive_filter(query, AvailabilityView.admin1_code, admin1_code)
+    if admin1_name:
+        query = query.where(AvailabilityView.admin1_name.icontains(admin1_name))
+    if admin2_code:
+        query = case_insensitive_filter(query, AvailabilityView.admin2_code, admin2_code)
+    if admin2_name:
+        query = query.where(AvailabilityView.admin2_name.icontains(admin2_name))
+    if hapi_update_date_min:
+        query = query.where(AvailabilityView.hapi_updated_date >= hapi_update_date_min)
+    if hapi_update_date_max:
+        query = query.where(AvailabilityView.hapi_updated_date < hapi_update_date_max)
+
+    query = apply_pagination(query, pagination_parameters)
+    query = query.order_by(
+        AvailabilityView.category,
+        AvailabilityView.subcategory,
+        AvailabilityView.location_name,
+        AvailabilityView.location_code,
+        AvailabilityView.admin1_name,
+        AvailabilityView.admin1_code,
+        AvailabilityView.admin2_name,
+        AvailabilityView.admin2_code,
+    )
+
+    logger.debug(f'Executing SQL query: {query}')
+
+    result = await db.execute(query)
+    availabilities = result.scalars().all()
+
+    logger.info(f'Retrieved {len(availabilities)} rows from the database')
+
+    return availabilities

--- a/hdx_hapi/db/dao/availability_view_dao.py
+++ b/hdx_hapi/db/dao/availability_view_dao.py
@@ -22,8 +22,8 @@ async def availability_view_list(
     admin1_code: Optional[str] = None,
     admin2_name: Optional[str] = None,
     admin2_code: Optional[str] = None,
-    hapi_update_date_min: Optional[datetime.datetime] = None,
-    hapi_update_date_max: Optional[datetime.datetime] = None,
+    hapi_updated_date_min: Optional[datetime.datetime] = None,
+    hapi_updated_date_max: Optional[datetime.datetime] = None,
 ):
     logger.info(f'availability_view_list called with params: {locals()}')
 
@@ -45,10 +45,10 @@ async def availability_view_list(
         query = case_insensitive_filter(query, AvailabilityView.admin2_code, admin2_code)
     if admin2_name:
         query = query.where(AvailabilityView.admin2_name.icontains(admin2_name))
-    if hapi_update_date_min:
-        query = query.where(AvailabilityView.hapi_updated_date >= hapi_update_date_min)
-    if hapi_update_date_max:
-        query = query.where(AvailabilityView.hapi_updated_date < hapi_update_date_max)
+    if hapi_updated_date_min:
+        query = query.where(AvailabilityView.hapi_updated_date >= hapi_updated_date_min)
+    if hapi_updated_date_max:
+        query = query.where(AvailabilityView.hapi_updated_date < hapi_updated_date_max)
 
     query = apply_pagination(query, pagination_parameters)
     query = query.order_by(

--- a/hdx_hapi/db/models/views/all_views.py
+++ b/hdx_hapi/db/models/views/all_views.py
@@ -30,6 +30,9 @@ from hapi_schema.db_sector import view_params_sector
 from hapi_schema.db_wfp_commodity import view_params_wfp_commodity
 from hapi_schema.db_wfp_market import view_params_wfp_market
 from hapi_schema.db_patch import view_params_patch
+
+from hapi_schema.views import view_params_availability
+
 from hapi_schema.utils.enums import (
     CommodityCategory,
     DisabledMarker,
@@ -70,6 +73,8 @@ sector_view = view(view_params_sector.name, Base.metadata, view_params_sector.se
 wfp_commodity_view = view(view_params_wfp_commodity.name, Base.metadata, view_params_wfp_commodity.selectable)
 wfp_market_view = view(view_params_wfp_market.name, Base.metadata, view_params_wfp_market.selectable)
 patch_view = view(view_params_patch.name, Base.metadata, view_params_patch.selectable)
+
+availability_view = view(view_params_availability.name, Base.metadata, view_params_availability.selectable)
 
 
 class Admin1View(Base):
@@ -453,3 +458,16 @@ class PatchView(Base):
     patch_hash: Mapped[str] = column_property(patch_view.c.patch_hash)
     state: Mapped[str] = column_property(patch_view.c.state)
     execution_date: Mapped[datetime.datetime] = column_property(patch_view.c.execution_date)
+
+
+class AvailabilityView(Base):
+    __table__ = availability_view
+    category: Mapped[str] = column_property(availability_view.c.category)
+    subcategory: Mapped[str] = column_property(availability_view.c.subcategory)
+    location_name: Mapped[str] = column_property(availability_view.c.location_name)
+    location_code: Mapped[str] = column_property(availability_view.c.location_code)
+    admin1_name: Mapped[str] = column_property(availability_view.c.admin1_name)
+    admin1_code: Mapped[str] = column_property(availability_view.c.admin1_code)
+    admin2_name: Mapped[str] = column_property(availability_view.c.admin2_name)
+    admin2_code: Mapped[str] = column_property(availability_view.c.admin2_code)
+    hapi_updated_date: Mapped[datetime.datetime] = column_property(availability_view.c.hapi_updated_date)

--- a/hdx_hapi/db/models/views/all_views.py
+++ b/hdx_hapi/db/models/views/all_views.py
@@ -6,7 +6,6 @@ import datetime
 
 from decimal import Decimal
 from sqlalchemy.orm import column_property, Mapped
-from sqlalchemy.schema import PrimaryKeyConstraint
 from hdx_hapi.db.models.views.util.util import view
 from hdx_hapi.db.models.base import Base
 from hapi_schema.db_admin1 import view_params_admin1
@@ -76,7 +75,6 @@ wfp_market_view = view(view_params_wfp_market.name, Base.metadata, view_params_w
 patch_view = view(view_params_patch.name, Base.metadata, view_params_patch.selectable)
 
 availability_view = prepare_hapi_views()
-# availability_view = view(view_params_availability.name, Base.metadata, view_params_availability.selectable)
 
 
 class Admin1View(Base):
@@ -464,6 +462,7 @@ class PatchView(Base):
 
 class AvailabilityView(Base):
     __table__ = availability_view
+    __mapper_args__ = {'primary_key': [availability_view.c.category]}
     category: Mapped[str] = column_property(availability_view.c.category)
     subcategory: Mapped[str] = column_property(availability_view.c.subcategory)
     location_name: Mapped[str] = column_property(availability_view.c.location_name)

--- a/hdx_hapi/db/models/views/all_views.py
+++ b/hdx_hapi/db/models/views/all_views.py
@@ -6,6 +6,7 @@ import datetime
 
 from decimal import Decimal
 from sqlalchemy.orm import column_property, Mapped
+from sqlalchemy.schema import PrimaryKeyConstraint
 from hdx_hapi.db.models.views.util.util import view
 from hdx_hapi.db.models.base import Base
 from hapi_schema.db_admin1 import view_params_admin1
@@ -31,7 +32,7 @@ from hapi_schema.db_wfp_commodity import view_params_wfp_commodity
 from hapi_schema.db_wfp_market import view_params_wfp_market
 from hapi_schema.db_patch import view_params_patch
 
-from hapi_schema.views import view_params_availability
+from hapi_schema.views import prepare_hapi_views
 
 from hapi_schema.utils.enums import (
     CommodityCategory,
@@ -74,7 +75,8 @@ wfp_commodity_view = view(view_params_wfp_commodity.name, Base.metadata, view_pa
 wfp_market_view = view(view_params_wfp_market.name, Base.metadata, view_params_wfp_market.selectable)
 patch_view = view(view_params_patch.name, Base.metadata, view_params_patch.selectable)
 
-availability_view = view(view_params_availability.name, Base.metadata, view_params_availability.selectable)
+availability_view = prepare_hapi_views()
+# availability_view = view(view_params_availability.name, Base.metadata, view_params_availability.selectable)
 
 
 class Admin1View(Base):

--- a/hdx_hapi/db/models/views/all_views.py
+++ b/hdx_hapi/db/models/views/all_views.py
@@ -462,7 +462,19 @@ class PatchView(Base):
 
 class AvailabilityView(Base):
     __table__ = availability_view
-    __mapper_args__ = {'primary_key': [availability_view.c.category]}
+    __mapper_args__ = {
+        'primary_key': [
+            availability_view.c.category,
+            availability_view.c.subcategory,
+            availability_view.c.location_name,
+            availability_view.c.location_code,
+            availability_view.c.admin1_name,
+            availability_view.c.admin1_code,
+            availability_view.c.admin2_name,
+            availability_view.c.admin2_code,
+            availability_view.c.hapi_updated_date,
+        ]
+    }
     category: Mapped[str] = column_property(availability_view.c.category)
     subcategory: Mapped[str] = column_property(availability_view.c.subcategory)
     location_name: Mapped[str] = column_property(availability_view.c.location_name)

--- a/hdx_hapi/db/models/views/all_views.py
+++ b/hdx_hapi/db/models/views/all_views.py
@@ -5,33 +5,35 @@ This code was generated automatically using src/hapi_schema/utils/hapi_views_cod
 import datetime
 
 from decimal import Decimal
+from hapi_schema.utils.view_params import ViewParams
+from sqlalchemy import union_all
 from sqlalchemy.orm import column_property, Mapped
 from hdx_hapi.db.models.views.util.util import view
 from hdx_hapi.db.models.base import Base
 from hapi_schema.db_admin1 import view_params_admin1
 from hapi_schema.db_admin2 import view_params_admin2
-from hapi_schema.db_conflict_event import view_params_conflict_event
+from hapi_schema.db_conflict_event import view_params_conflict_event, availability_stmt_conflict_event
 from hapi_schema.db_currency import view_params_currency
 from hapi_schema.db_dataset import view_params_dataset
-from hapi_schema.db_food_price import view_params_food_price
-from hapi_schema.db_food_security import view_params_food_security
-from hapi_schema.db_funding import view_params_funding
-from hapi_schema.db_humanitarian_needs import view_params_humanitarian_needs
+from hapi_schema.db_food_price import view_params_food_price, availability_stmt_food_price
+from hapi_schema.db_food_security import view_params_food_security, availability_stmt_food_security
+from hapi_schema.db_funding import view_params_funding, availability_stmt_funding
+from hapi_schema.db_humanitarian_needs import view_params_humanitarian_needs, availability_stmt_humanitarian_needs
 from hapi_schema.db_location import view_params_location
-from hapi_schema.db_national_risk import view_params_national_risk
-from hapi_schema.db_operational_presence import view_params_operational_presence
+from hapi_schema.db_national_risk import view_params_national_risk, availability_stmt_national_risk
+from hapi_schema.db_operational_presence import view_params_operational_presence, availability_stmt_operational_presence
 from hapi_schema.db_org_type import view_params_org_type
 from hapi_schema.db_org import view_params_org
-from hapi_schema.db_population import view_params_population
-from hapi_schema.db_poverty_rate import view_params_poverty_rate
-from hapi_schema.db_refugees import view_params_refugees
+from hapi_schema.db_population import view_params_population, availability_stmt_population
+from hapi_schema.db_poverty_rate import view_params_poverty_rate, availability_stmt_poverty_rate
+from hapi_schema.db_refugees import view_params_refugees, availability_stmt_refugees
 from hapi_schema.db_resource import view_params_resource
 from hapi_schema.db_sector import view_params_sector
 from hapi_schema.db_wfp_commodity import view_params_wfp_commodity
 from hapi_schema.db_wfp_market import view_params_wfp_market
 from hapi_schema.db_patch import view_params_patch
-
-from hapi_schema.views import prepare_hapi_views
+from hapi_schema.db_returnees import availability_stmt_returnees
+from hapi_schema.db_idps import availability_stmt_idps
 
 from hapi_schema.utils.enums import (
     CommodityCategory,
@@ -46,6 +48,54 @@ from hapi_schema.utils.enums import (
     RiskClass,
     Gender,
 )
+
+def create_view_params_availability() -> ViewParams:
+    availability_stmts = [
+        availability_stmt_conflict_event,
+        availability_stmt_food_price,
+        availability_stmt_food_security,
+        availability_stmt_funding,
+        availability_stmt_humanitarian_needs,
+        availability_stmt_national_risk,
+        availability_stmt_operational_presence,
+        availability_stmt_population,
+        availability_stmt_poverty_rate,
+        availability_stmt_refugees,
+        availability_stmt_returnees,
+        availability_stmt_idps,
+    ]
+    return ViewParams(
+        name='data_availability_view',
+        metadata=Base.metadata,
+        selectable=union_all(*availability_stmts),
+    )
+
+view_params_availability = create_view_params_availability()
+
+VIEW_LIST = [
+    view_params_admin1,
+    view_params_admin2,
+    view_params_location,
+    view_params_dataset,
+    view_params_food_security,
+    view_params_funding,
+    view_params_humanitarian_needs,
+    view_params_national_risk,
+    view_params_operational_presence,
+    view_params_org_type,
+    view_params_org,
+    view_params_population,
+    view_params_refugees,
+    view_params_resource,
+    view_params_sector,
+    view_params_conflict_event,
+    view_params_poverty_rate,
+    view_params_wfp_commodity,
+    view_params_wfp_market,
+    view_params_currency,
+    view_params_food_price,
+    view_params_availability,
+]
 
 admin1_view = view(view_params_admin1.name, Base.metadata, view_params_admin1.selectable)
 admin2_view = view(view_params_admin2.name, Base.metadata, view_params_admin2.selectable)
@@ -74,7 +124,7 @@ wfp_commodity_view = view(view_params_wfp_commodity.name, Base.metadata, view_pa
 wfp_market_view = view(view_params_wfp_market.name, Base.metadata, view_params_wfp_market.selectable)
 patch_view = view(view_params_patch.name, Base.metadata, view_params_patch.selectable)
 
-availability_view = prepare_hapi_views()
+availability_view = view(view_params_availability.name, Base.metadata, view_params_availability.selectable)
 
 
 class Admin1View(Base):

--- a/hdx_hapi/db/models/views/vat_or_view.py
+++ b/hdx_hapi/db/models/views/vat_or_view.py
@@ -26,6 +26,7 @@ if not USE_VAT:
         FoodSecurityView,
         FundingView,
         RefugeesView,
+        AvailabilityView,
     )
 else:
     from hapi_schema.db_views_as_tables import (
@@ -50,4 +51,5 @@ else:
         DBFoodSecurityVAT as FoodSecurityView,
         DBFundingVAT as FundingView,
         DBRefugeesVAT as RefugeesView,
+        DBAvailabilityVAT as AvailabilityView,
     )

--- a/hdx_hapi/endpoints/get_data_availability.py
+++ b/hdx_hapi/endpoints/get_data_availability.py
@@ -73,11 +73,11 @@ async def get_data_availability(
     admin2_name: Annotated[
         Optional[str], Query(max_length=512, description=f'{DOC_ADMIN2_NAME} {DOC_SEE_ADMIN2}')
     ] = None,
-    hapi_update_date_min: Annotated[
+    hapi_updated_date_min: Annotated[
         datetime.datetime | datetime.date,
         Query(description=f'{DOC_UPDATE_DATE_MIN}'),
     ] = None,
-    hapi_update_date_max: Annotated[
+    hapi_updated_date_max: Annotated[
         datetime.datetime | datetime.date,
         Query(description=f'{DOC_UPDATE_DATE_MAX}'),
     ] = None,
@@ -97,7 +97,7 @@ async def get_data_availability(
         admin1_code=admin1_code,
         admin2_name=admin2_name,
         admin2_code=admin2_code,
-        hapi_update_date_min=hapi_update_date_min,
-        hapi_update_date_max=hapi_update_date_max,
+        hapi_updated_date_min=hapi_updated_date_min,
+        hapi_updated_date_max=hapi_updated_date_max,
     )
     return transform_result_to_csv_stream_if_requested(result, output_format, AvailabilityResponse)

--- a/hdx_hapi/endpoints/get_data_availability.py
+++ b/hdx_hapi/endpoints/get_data_availability.py
@@ -1,0 +1,103 @@
+import datetime
+from typing import Annotated, Optional
+from fastapi import Depends, Query, APIRouter
+
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from hdx_hapi.config.doc_snippets import (
+    DOC_LOCATION_NAME,
+    DOC_LOCATION_CODE,
+    DOC_SEE_LOC,
+    DOC_ADMIN1_NAME,
+    DOC_ADMIN1_CODE,
+    DOC_SEE_ADMIN1,
+    DOC_ADMIN2_NAME,
+    DOC_ADMIN2_CODE,
+    DOC_SEE_ADMIN2,
+    DOC_UPDATE_DATE_MIN,
+    DOC_UPDATE_DATE_MAX,
+)
+
+from hdx_hapi.endpoints.models.base import HapiGenericResponse
+from hdx_hapi.endpoints.models.availability import AvailabilityResponse
+from hdx_hapi.endpoints.util.util import (
+    CommonEndpointParams,
+    OutputFormat,
+    common_endpoint_parameters,
+)
+from hdx_hapi.services.csv_transform_logic import transform_result_to_csv_stream_if_requested
+
+from hdx_hapi.services.availability_logic import get_availability_srv
+from hdx_hapi.services.sql_alchemy_session import get_db
+
+router = APIRouter(
+    tags=['Metadata'],
+)
+
+
+@router.get(
+    '/api/metadata/data-availability',
+    response_model=HapiGenericResponse[AvailabilityResponse],
+    summary='Get information about the availability of data for different geographic admin levels',
+    include_in_schema=False,
+)
+@router.get(
+    '/api/v1/metadata/data-availability',
+    response_model=HapiGenericResponse[AvailabilityResponse],
+    summary='Get information about the availability of data for different geographic admin levels',
+)
+async def get_data_availability(
+    common_parameters: Annotated[CommonEndpointParams, Depends(common_endpoint_parameters)],
+    db: AsyncSession = Depends(get_db),
+    category: Annotated[
+        Optional[str], Query(max_length=128, description='Filter the response by a data category')
+    ] = None,
+    subcategory: Annotated[
+        Optional[str], Query(max_length=128, description='Filter the response by a data subcategory')
+    ] = None,
+    location_code: Annotated[
+        Optional[str], Query(max_length=128, description=f'{DOC_LOCATION_CODE} {DOC_SEE_LOC}')
+    ] = None,
+    location_name: Annotated[
+        Optional[str], Query(max_length=512, description=f'{DOC_LOCATION_NAME} {DOC_SEE_LOC}')
+    ] = None,
+    admin1_code: Annotated[
+        Optional[str], Query(max_length=128, description=f'{DOC_ADMIN1_CODE} {DOC_SEE_ADMIN1}')
+    ] = None,
+    admin1_name: Annotated[
+        Optional[str], Query(max_length=512, description=f'{DOC_ADMIN1_NAME} {DOC_SEE_ADMIN1}')
+    ] = None,
+    admin2_code: Annotated[
+        Optional[str], Query(max_length=128, description=f'{DOC_ADMIN2_CODE} {DOC_SEE_ADMIN2}')
+    ] = None,
+    admin2_name: Annotated[
+        Optional[str], Query(max_length=512, description=f'{DOC_ADMIN2_NAME} {DOC_SEE_ADMIN2}')
+    ] = None,
+    hapi_update_date_min: Annotated[
+        datetime.datetime | datetime.date,
+        Query(description=f'{DOC_UPDATE_DATE_MIN}'),
+    ] = None,
+    hapi_update_date_max: Annotated[
+        datetime.datetime | datetime.date,
+        Query(description=f'{DOC_UPDATE_DATE_MAX}'),
+    ] = None,
+    output_format: OutputFormat = OutputFormat.JSON,
+):
+    """
+    Provide currency information to use in conjunction with the food-prices endpoint
+    """
+    result = await get_availability_srv(
+        pagination_parameters=common_parameters,
+        db=db,
+        category=category,
+        subcategory=subcategory,
+        location_name=location_name,
+        location_code=location_code,
+        admin1_name=admin1_name,
+        admin1_code=admin1_code,
+        admin2_name=admin2_name,
+        admin2_code=admin2_code,
+        hapi_update_date_min=hapi_update_date_min,
+        hapi_update_date_max=hapi_update_date_max,
+    )
+    return transform_result_to_csv_stream_if_requested(result, output_format, AvailabilityResponse)

--- a/hdx_hapi/endpoints/models/availability.py
+++ b/hdx_hapi/endpoints/models/availability.py
@@ -1,9 +1,29 @@
+import datetime
+from typing import Optional
 from pydantic import ConfigDict, Field
-from hdx_hapi.endpoints.models.base import HapiBaseModel, HapiModelWithAdmins
+from hdx_hapi.endpoints.models.base import HapiBaseModel
+from hdx_hapi.config.doc_snippets import (
+    truncate_query_description,
+    DOC_LOCATION_CODE,
+    DOC_LOCATION_NAME,
+    DOC_ADMIN1_CODE,
+    DOC_ADMIN1_NAME,
+    DOC_ADMIN2_CODE,
+    DOC_ADMIN2_NAME,
+)
 
 
-class AvailabilityResponse(HapiBaseModel, HapiModelWithAdmins):
+class AvailabilityResponse(HapiBaseModel):
     category: str = Field(max_length=32, description='HAPI category')
     subcategory: str = Field(max_length=512, description='HAPI subcategory')
+    location_code: str = Field(max_length=128, description=truncate_query_description(DOC_LOCATION_CODE))
+    location_name: str = Field(max_length=512, description=truncate_query_description(DOC_LOCATION_NAME))
+    admin1_code: Optional[str] = Field(max_length=128, description=truncate_query_description(DOC_ADMIN1_CODE))
+    admin1_name: Optional[str] = Field(max_length=512, description=truncate_query_description(DOC_ADMIN1_NAME))
+    admin2_code: Optional[str] = Field(max_length=128, description=truncate_query_description(DOC_ADMIN2_CODE))
+    admin2_name: Optional[str] = Field(max_length=512, description=truncate_query_description(DOC_ADMIN2_NAME))
+    hapi_updated_date: Optional[datetime.datetime] = Field(
+        description='Date that datasets was last updated, e.g. 2020-01-01 or 2020-01-01T00:00:00'
+    )
 
     model_config = ConfigDict(from_attributes=True)

--- a/hdx_hapi/endpoints/models/availability.py
+++ b/hdx_hapi/endpoints/models/availability.py
@@ -1,0 +1,9 @@
+from pydantic import ConfigDict, Field
+from hdx_hapi.endpoints.models.base import HapiBaseModel, HapiModelWithAdmins
+
+
+class AvailabilityResponse(HapiBaseModel, HapiModelWithAdmins):
+    category: str = Field(max_length=32, description='HAPI category')
+    subcategory: str = Field(max_length=512, description='HAPI subcategory')
+
+    model_config = ConfigDict(from_attributes=True)

--- a/hdx_hapi/endpoints/models/availability.py
+++ b/hdx_hapi/endpoints/models/availability.py
@@ -23,7 +23,7 @@ class AvailabilityResponse(HapiBaseModel):
     admin2_code: Optional[str] = Field(max_length=128, description=truncate_query_description(DOC_ADMIN2_CODE))
     admin2_name: Optional[str] = Field(max_length=512, description=truncate_query_description(DOC_ADMIN2_NAME))
     hapi_updated_date: Optional[datetime.datetime] = Field(
-        description='Date that datasets was last updated, e.g. 2020-01-01 or 2020-01-01T00:00:00'
+        description='Date that dataset was last updated, e.g. 2020-01-01 or 2020-01-01T00:00:00'
     )
 
     model_config = ConfigDict(from_attributes=True)

--- a/hdx_hapi/services/availability_logic.py
+++ b/hdx_hapi/services/availability_logic.py
@@ -1,0 +1,36 @@
+import datetime
+from typing import Optional
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from hdx_hapi.db.dao.availability_view_dao import availability_view_list
+from hdx_hapi.endpoints.util.util import PaginationParams
+
+
+async def get_availability_srv(
+    pagination_parameters: PaginationParams,
+    db: AsyncSession,
+    category: Optional[str] = None,
+    subcategory: Optional[str] = None,
+    location_name: Optional[str] = None,
+    location_code: Optional[str] = None,
+    admin1_name: Optional[str] = None,
+    admin1_code: Optional[str] = None,
+    admin2_name: Optional[str] = None,
+    admin2_code: Optional[str] = None,
+    hapi_update_date_min: Optional[datetime.datetime] = None,
+    hapi_update_date_max: Optional[datetime.datetime] = None,
+):
+    return await availability_view_list(
+        pagination_parameters=pagination_parameters,
+        db=db,
+        category=category,
+        subcategory=subcategory,
+        location_name=location_name,
+        location_code=location_code,
+        admin1_name=admin1_name,
+        admin1_code=admin1_code,
+        admin2_name=admin2_name,
+        admin2_code=admin2_code,
+        hapi_update_date_min=hapi_update_date_min,
+        hapi_update_date_max=hapi_update_date_max,
+    )

--- a/hdx_hapi/services/availability_logic.py
+++ b/hdx_hapi/services/availability_logic.py
@@ -17,8 +17,8 @@ async def get_availability_srv(
     admin1_code: Optional[str] = None,
     admin2_name: Optional[str] = None,
     admin2_code: Optional[str] = None,
-    hapi_update_date_min: Optional[datetime.datetime] = None,
-    hapi_update_date_max: Optional[datetime.datetime] = None,
+    hapi_updated_date_min: Optional[datetime.datetime] = None,
+    hapi_updated_date_max: Optional[datetime.datetime] = None,
 ):
     return await availability_view_list(
         pagination_parameters=pagination_parameters,
@@ -31,6 +31,6 @@ async def get_availability_srv(
         admin1_code=admin1_code,
         admin2_name=admin2_name,
         admin2_code=admin2_code,
-        hapi_update_date_min=hapi_update_date_min,
-        hapi_update_date_max=hapi_update_date_max,
+        hapi_updated_date_min=hapi_updated_date_min,
+        hapi_updated_date_max=hapi_updated_date_max,
     )

--- a/main.py
+++ b/main.py
@@ -33,6 +33,7 @@ from hdx_hapi.endpoints.get_wfp_market import router as wfp_market_router  # noq
 from hdx_hapi.endpoints.get_currency import router as currency_router  # noqa
 from hdx_hapi.endpoints.get_food_security import router as food_security_router  # noqa
 from hdx_hapi.endpoints.get_food_price import router as food_price_router  # noqa
+from hdx_hapi.endpoints.get_data_availability import router as data_availability_router  # noqa
 
 from hdx_hapi.endpoints.get_version import router as version_router  # noqa
 
@@ -96,6 +97,7 @@ app.include_router(humanitarian_response_router)
 app.include_router(wfp_commodity_router)
 app.include_router(wfp_market_router)
 
+app.include_router(data_availability_router)
 app.include_router(version_router)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ ua-parser==0.18.0
 alembic~=1.12.00
 psycopg2~=2.9.7
 
--e git+https://github.com/OCHA-DAP/hapi-sqlalchemy-schema@v0.8.14#egg=hapi-schema
+-e git+https://github.com/OCHA-DAP/hapi-sqlalchemy-schema@v0.8.16#egg=hapi-schema

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,6 @@ ua-parser==0.18.0
 alembic~=1.12.00
 psycopg2~=2.9.7
 
+hdx-python-database>=1.3.3
+
 -e git+https://github.com/OCHA-DAP/hapi-sqlalchemy-schema@v0.8.16#egg=hapi-schema

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,4 @@ ua-parser==0.18.0
 alembic~=1.12.00
 psycopg2~=2.9.7
 
-hdx-python-database>=1.3.3
-
 -e git+https://github.com/OCHA-DAP/hapi-sqlalchemy-schema@v0.8.16#egg=hapi-schema

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,7 @@ def pytest_sessionstart(session):
 def _create_tables_and_views(engine: Engine):
     Base.metadata.create_all(engine)
     with engine.connect() as conn:
+        _ = prepare_hapi_views()
         for v in VIEW_LIST:
             print(f'Creating view {v.name}', flush=True)
             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,9 +98,9 @@ def pytest_sessionstart(session):
 
 
 def _create_tables_and_views(engine: Engine):
+    _ = prepare_hapi_views()
     Base.metadata.create_all(engine)
     with engine.connect() as conn:
-        _ = prepare_hapi_views()
         for v in VIEW_LIST:
             print(f'Creating view {v.name}', flush=True)
             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,40 +3,16 @@ import pytest
 import os
 import logging
 
-from hdx.database import Database  # noqa
-
 from logging import Logger
-import sqlalchemy
 from sqlalchemy import Engine, MetaData, create_engine, inspect, text
 from sqlalchemy.orm import sessionmaker, Session
 from typing import List
 
-from hapi_schema.db_admin1 import view_params_admin1
-from hapi_schema.db_admin2 import view_params_admin2
-from hapi_schema.db_dataset import view_params_dataset
-from hapi_schema.db_food_security import view_params_food_security
-from hapi_schema.db_funding import view_params_funding
-from hapi_schema.db_humanitarian_needs import view_params_humanitarian_needs
-from hapi_schema.db_location import view_params_location
-from hapi_schema.db_national_risk import view_params_national_risk
-from hapi_schema.db_operational_presence import view_params_operational_presence
-from hapi_schema.db_org_type import view_params_org_type
-from hapi_schema.db_org import view_params_org
-from hapi_schema.db_population import view_params_population
-from hapi_schema.db_refugees import view_params_refugees
-from hapi_schema.db_resource import view_params_resource
-from hapi_schema.db_sector import view_params_sector
-from hapi_schema.db_conflict_event import view_params_conflict_event
-from hapi_schema.db_poverty_rate import view_params_poverty_rate
-from hapi_schema.db_wfp_commodity import view_params_wfp_commodity
-from hapi_schema.db_wfp_market import view_params_wfp_market
-from hapi_schema.db_currency import view_params_currency
-from hapi_schema.db_food_price import view_params_food_price
-from hapi_schema.views import prepare_hapi_views
-
 from hdx_hapi.config.config import get_config
 from hdx_hapi.db.models.base import Base
-from hdx_hapi.db.models.views.util.util import CreateView
+
+# This is needed so that the views are recognized by sqlAlchemy
+from hdx_hapi.db.models.views.all_views import VIEW_LIST # noqa
 
 
 SAMPLE_DATA_SQL_FILES = [
@@ -60,30 +36,6 @@ SAMPLE_DATA_SQL_FILES = [
     'tests/sample_data/food_price.sql',
 ]
 
-VIEW_LIST = [
-    view_params_admin1,
-    view_params_admin2,
-    view_params_location,
-    view_params_dataset,
-    view_params_food_security,
-    view_params_funding,
-    view_params_humanitarian_needs,
-    view_params_national_risk,
-    view_params_operational_presence,
-    view_params_org_type,
-    view_params_org,
-    view_params_population,
-    view_params_refugees,
-    view_params_resource,
-    view_params_sector,
-    view_params_conflict_event,
-    view_params_poverty_rate,
-    view_params_wfp_commodity,
-    view_params_wfp_market,
-    view_params_currency,
-    view_params_food_price,
-]
-
 
 def pytest_sessionstart(session):
     os.environ['HAPI_DB_NAME'] = 'hapi_test'
@@ -98,20 +50,15 @@ def pytest_sessionstart(session):
 
 
 def _create_tables_and_views(engine: Engine):
-    _ = prepare_hapi_views()
     Base.metadata.create_all(engine)
-    with engine.connect() as conn:
-        for v in VIEW_LIST:
-            print(f'Creating view {v.name}', flush=True)
-            try:
-                conn.execute(CreateView(v.name, v.selectable))
-                conn.commit()
-            except (sqlalchemy.exc.ProgrammingError, sqlalchemy.exc.InternalError):
-                print('..already exists', flush=True)
-    # try:
-    #     _ = prepare_hapi_views()
-    # except:  # noqa
-    #     print('prepare_hapi_views failed', flush=True)
+    # with engine.connect() as conn:
+    #     for v in VIEW_LIST:
+    #         print(f'Creating view {v.name}', flush=True)
+    #         try:
+    #             conn.execute(CreateView(v.name, v.selectable))
+    #             conn.commit()
+    #         except (sqlalchemy.exc.ProgrammingError, sqlalchemy.exc.InternalError) as e:
+    #             print('..already exists', flush=True)
 
 
 def _drop_tables_and_views(engine: Engine):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,10 +97,6 @@ def pytest_sessionstart(session):
 
 
 def _create_tables_and_views(engine: Engine):
-    try:
-        _ = prepare_hapi_views()
-    except:  # noqa
-        print('prepare_hapi_views failed', flush=True)
     Base.metadata.create_all(engine)
     with engine.connect() as conn:
         for v in VIEW_LIST:
@@ -110,6 +106,10 @@ def _create_tables_and_views(engine: Engine):
                 conn.commit()
             except (sqlalchemy.exc.ProgrammingError, sqlalchemy.exc.InternalError):
                 print('..already exists', flush=True)
+    try:
+        _ = prepare_hapi_views()
+    except:  # noqa
+        print('prepare_hapi_views failed', flush=True)
 
 
 def _drop_tables_and_views(engine: Engine):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,7 +99,7 @@ def pytest_sessionstart(session):
 def _create_tables_and_views(engine: Engine):
     try:
         _ = prepare_hapi_views()
-    except:
+    except:  # noqa
         print('prepare_hapi_views failed', flush=True)
     Base.metadata.create_all(engine)
     with engine.connect() as conn:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import pytest
 import os
 import logging
 
+from hdx.database import Database  # noqa
 
 from logging import Logger
 import sqlalchemy
@@ -107,10 +108,10 @@ def _create_tables_and_views(engine: Engine):
                 conn.commit()
             except (sqlalchemy.exc.ProgrammingError, sqlalchemy.exc.InternalError):
                 print('..already exists', flush=True)
-    try:
-        _ = prepare_hapi_views()
-    except:  # noqa
-        print('prepare_hapi_views failed', flush=True)
+    # try:
+    #     _ = prepare_hapi_views()
+    # except:  # noqa
+    #     print('prepare_hapi_views failed', flush=True)
 
 
 def _drop_tables_and_views(engine: Engine):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,7 +97,10 @@ def pytest_sessionstart(session):
 
 
 def _create_tables_and_views(engine: Engine):
-    _ = prepare_hapi_views()
+    try:
+        _ = prepare_hapi_views()
+    except:
+        print('prepare_hapi_views failed', flush=True)
     Base.metadata.create_all(engine)
     with engine.connect() as conn:
         for v in VIEW_LIST:

--- a/tests/test_endpoints/endpoint_data.py
+++ b/tests/test_endpoints/endpoint_data.py
@@ -69,6 +69,31 @@ endpoint_data = {
             'reference_period_end',
         ],
     },
+    '/api/v1/metadata/data-availability': {
+        'query_parameters': {
+            'category': 'coordination-context',
+            'subcategory': 'conflict-event',
+            'location_code': 'FOO',
+            'location_name': 'Foolandia',
+            'admin1_code': 'FOO-001',
+            'admin1_name': 'Province 01',
+            'admin2_code': 'FOO-001-A',
+            'admin2_name': 'District A',
+            'update_date_min': date(2022, 6, 1),
+            'update_date_max': date(2023, 6, 3),
+        },
+        'expected_fields': [
+            'category',
+            'subcategory',
+            'location_code',
+            'location_name',
+            'admin1_code',
+            'admin1_name',
+            'admin2_code',
+            'admin2_name',
+            'hapi_updated_date',
+        ],
+    },
     '/api/v1/metadata/dataset': {
         'query_parameters': {
             'dataset_hdx_id': '90deb235-1bf5-4bae-b231-3393222c2d01',

--- a/tests/test_endpoints/test_data_availability_endpoint.py
+++ b/tests/test_endpoints/test_data_availability_endpoint.py
@@ -32,8 +32,8 @@ async def test_get_data_availability_params(event_loop, refresh_db):
 
         assert response.status_code == 200
         assert len(response.json()['data']) > 0, (
-            f'There should be at least one data availability entry for parameter "{param_name}" with value "{param_value}" '
-            'in the database'
+            f'There should be at least one data availability entry for parameter "{param_name}" '
+            f'with value "{param_value}" in the database'
         )
 
     async with AsyncClient(app=app, base_url='http://test', params=query_parameters) as ac:

--- a/tests/test_endpoints/test_data_availability_endpoint.py
+++ b/tests/test_endpoints/test_data_availability_endpoint.py
@@ -1,0 +1,60 @@
+import pytest
+import logging
+
+from httpx import AsyncClient
+from main import app
+from tests.test_endpoints.endpoint_data import endpoint_data
+
+log = logging.getLogger(__name__)
+
+ENDPOINT_ROUTER = '/api/v1/metadata/data-availability'
+endpoint_data = endpoint_data[ENDPOINT_ROUTER]
+query_parameters = endpoint_data['query_parameters']
+expected_fields = endpoint_data['expected_fields']
+
+
+@pytest.mark.asyncio
+async def test_get_data_availability(event_loop, refresh_db):
+    log.info('started test_get_data_availability')
+    async with AsyncClient(app=app, base_url='http://test') as ac:
+        response = await ac.get(ENDPOINT_ROUTER)
+    assert response.status_code == 200
+    assert len(response.json()['data']) > 0, 'There should be at least one data availability row in the database'
+
+
+@pytest.mark.asyncio
+async def test_get_data_availability_params(event_loop, refresh_db):
+    log.info('started test_get_data_availability_params')
+
+    for param_name, param_value in query_parameters.items():
+        async with AsyncClient(app=app, base_url='http://test', params={param_name: param_value}) as ac:
+            response = await ac.get(ENDPOINT_ROUTER)
+
+        assert response.status_code == 200
+        assert len(response.json()['data']) > 0, (
+            f'There should be at least one data availability entry for parameter "{param_name}" with value "{param_value}" '
+            'in the database'
+        )
+
+    async with AsyncClient(app=app, base_url='http://test', params=query_parameters) as ac:
+        response = await ac.get(ENDPOINT_ROUTER)
+
+    assert response.status_code == 200
+    assert (
+        len(response.json()['data']) > 0
+    ), 'There should be at least one availability row for all parameters in the database'
+
+
+@pytest.mark.asyncio
+async def test_get_data_availability_result(event_loop, refresh_db):
+    log.info('started test_get_data_availability_result')
+
+    async with AsyncClient(app=app, base_url='http://test', params=query_parameters) as ac:
+        response = await ac.get(ENDPOINT_ROUTER)
+
+    for field in expected_fields:
+        assert field in response.json()['data'][0], f'Field "{field}" not found in the response'
+
+    assert len(response.json()['data'][0]) == len(
+        expected_fields
+    ), 'Response has a different number of fields than expected'

--- a/tests/test_endpoints/test_endpoints_vs_encode_identifier.py
+++ b/tests/test_endpoints/test_endpoints_vs_encode_identifier.py
@@ -9,26 +9,29 @@ from main import app
 log = logging.getLogger(__name__)
 
 ENDPOINT_ROUTER_LIST = [
-    '/api/v1/metadata/admin1',
-    '/api/v1/metadata/admin2',
-    '/api/v1/metadata/dataset',
-    '/api/v1/affected-people/humanitarian-needs',
-    '/api/v1/metadata/location',
-    '/api/v1/metadata/org',
-    '/api/v1/metadata/org-type',
-    '/api/v1/metadata/resource',
-    '/api/v1/metadata/sector',
-    '/api/v1/population-social/population',
-    '/api/v1/population-social/poverty-rate',
-    '/api/v1/coordination-context/national-risk',
-    '/api/v1/coordination-context/operational-presence',
     '/api/v1/affected-people/refugees',
+    '/api/v1/affected-people/humanitarian-needs',
+    '/api/v1/coordination-context/operational-presence',
     '/api/v1/coordination-context/funding',
     '/api/v1/coordination-context/conflict-event',
+    '/api/v1/coordination-context/national-risk',
     '/api/v1/food/food-security',
+    '/api/v1/food/food-price',
+    '/api/v1/population-social/population',
+    '/api/v1/population-social/poverty-rate',
+    '/api/v1/metadata/dataset',
+    '/api/v1/metadata/resource',
+    '/api/v1/metadata/location',
+    '/api/v1/metadata/admin1',
+    '/api/v1/metadata/admin2',
+    '/api/v1/metadata/org',
+    '/api/v1/metadata/org-type',
+    '/api/v1/metadata/sector',
     '/api/v1/metadata/currency',
+    '/api/v1/metadata/wfp-commodity',
+    '/api/v1/metadata/wfp-market',
+    '/api/v1/metadata/data-availability',
 ]
-
 
 APP_IDENTIFIER = 'aGFwaV90ZXN0OmhhcGlAaHVtZGF0YS5vcmc='
 query_parameters = {'app_identifier': APP_IDENTIFIER}


### PR DESCRIPTION
This PR adds the new data availability endpoint.

The challenging part of this PR was getting the import/creation of the `data_availability_view` to work. This is done in `hdx_hapi/db/models/views/all_views.py` by adding `from hapi_schema.views import prepare_hapi_views` whose final act is to create the `data_availability_view`. The class `AvailabilityView` needs to specify the primary keys for this view.

For GitHub Actions it was necessary to add `from hdx.database import Database  # noqa` to `conftest.py` otherwise the Database was not initialised when the `prepare_hapi_views` call was made, however this was not necessary locally. 

The list of endpoints in `tests/test_endpoints/test_endpoints_vs_encode_identifier.py` has been updated to include all the endpoints, and reordered to match the order they appear in the docs ui.