### PR TITLE
PR Feature/HDX-10280 availability admin levels

### DIFF
--- a/hdx_hapi/db/dao/availability_view_dao.py
+++ b/hdx_hapi/db/dao/availability_view_dao.py
@@ -2,7 +2,8 @@ import datetime
 import logging
 from typing import Optional
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+from sqlalchemy import Select, select, or_
+from sqlalchemy.orm import Mapped
 
 from hdx_hapi.db.models.views.vat_or_view import AvailabilityView
 from hdx_hapi.db.dao.util.util import apply_pagination, case_insensitive_filter
@@ -54,14 +55,14 @@ async def availability_view_list(
     # Admin level filtering. Filtering by admin level is handled differently for the data availability table
     # beause we don't have the adminX_is_unspecified fields.
     if admin_level == AdminLevel.ZERO:
-        query = case_insensitive_filter(query, AvailabilityView.admin1_name, _UNSPECIFIED)
-        query = case_insensitive_filter(query, AvailabilityView.admin2_name, _UNSPECIFIED)
+        query = filter_is_unspecified(query, AvailabilityView.admin1_name)
+        query = filter_is_unspecified(query, AvailabilityView.admin2_name)
     elif admin_level == AdminLevel.ONE:
-        query = query.where(~AvailabilityView.admin1_name.ilike(_UNSPECIFIED))
-        query = case_insensitive_filter(query, AvailabilityView.admin2_name, _UNSPECIFIED)
+        query = filter_is_unspecified(query, AvailabilityView.admin1_name, negate=True)
+        query = filter_is_unspecified(query, AvailabilityView.admin2_name)
     elif admin_level == AdminLevel.TWO:
-        query = query.where(~AvailabilityView.admin1_name.ilike(_UNSPECIFIED))
-        query = query.where(~AvailabilityView.admin2_name.ilike(_UNSPECIFIED))
+        query = filter_is_unspecified(query, AvailabilityView.admin1_name, negate=True)
+        query = filter_is_unspecified(query, AvailabilityView.admin2_name, negate=True)
 
     query = apply_pagination(query, pagination_parameters)
     query = query.order_by(
@@ -83,3 +84,11 @@ async def availability_view_list(
     logger.info(f'Retrieved {len(availabilities)} rows from the database')
 
     return availabilities
+
+def filter_is_unspecified(query: Select, column: Mapped[str], negate=False) -> Select:
+    or_clause = or_(column == '', column.is_(None), column.ilike(_UNSPECIFIED))
+    if negate:
+        return query.where(~or_clause)
+    else:
+        return query.where(or_clause)
+    

--- a/hdx_hapi/db/dao/availability_view_dao.py
+++ b/hdx_hapi/db/dao/availability_view_dao.py
@@ -6,10 +6,10 @@ from sqlalchemy import select
 
 from hdx_hapi.db.models.views.vat_or_view import AvailabilityView
 from hdx_hapi.db.dao.util.util import apply_pagination, case_insensitive_filter
-from hdx_hapi.endpoints.util.util import PaginationParams
+from hdx_hapi.endpoints.util.util import AdminLevel, PaginationParams
 
 logger = logging.getLogger(__name__)
-
+_UNSPECIFIED = 'UNSPECIFIED'
 
 async def availability_view_list(
     pagination_parameters: PaginationParams,
@@ -24,6 +24,7 @@ async def availability_view_list(
     admin2_code: Optional[str] = None,
     hapi_updated_date_min: Optional[datetime.datetime | datetime.date] = None,
     hapi_updated_date_max: Optional[datetime.datetime | datetime.date] = None,
+    admin_level: Optional[AdminLevel] = None,
 ):
     logger.info(f'availability_view_list called with params: {locals()}')
 
@@ -49,6 +50,18 @@ async def availability_view_list(
         query = query.where(AvailabilityView.hapi_updated_date >= hapi_updated_date_min)
     if hapi_updated_date_max:
         query = query.where(AvailabilityView.hapi_updated_date < hapi_updated_date_max)
+
+    # Admin level filtering. Filtering by admin level is handled differently for the data availability table
+    # beause we don't have the adminX_is_unspecified fields.
+    if admin_level == AdminLevel.ZERO:
+        query = case_insensitive_filter(query, AvailabilityView.admin1_name, _UNSPECIFIED)
+        query = case_insensitive_filter(query, AvailabilityView.admin2_name, _UNSPECIFIED)
+    elif admin_level == AdminLevel.ONE:
+        query = query.where(~AvailabilityView.admin1_name.ilike(_UNSPECIFIED))
+        query = case_insensitive_filter(query, AvailabilityView.admin2_name, _UNSPECIFIED)
+    elif admin_level == AdminLevel.TWO:
+        query = query.where(~AvailabilityView.admin1_name.ilike(_UNSPECIFIED))
+        query = query.where(~AvailabilityView.admin2_name.ilike(_UNSPECIFIED))
 
     query = apply_pagination(query, pagination_parameters)
     query = query.order_by(

--- a/hdx_hapi/endpoints/get_data_availability.py
+++ b/hdx_hapi/endpoints/get_data_availability.py
@@ -5,6 +5,7 @@ from fastapi import Depends, Query, APIRouter
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from hdx_hapi.config.doc_snippets import (
+    DOC_ADMIN_LEVEL_FILTER,
     DOC_LOCATION_NAME,
     DOC_LOCATION_CODE,
     DOC_SEE_LOC,
@@ -21,6 +22,7 @@ from hdx_hapi.config.doc_snippets import (
 from hdx_hapi.endpoints.models.base import HapiGenericResponse
 from hdx_hapi.endpoints.models.availability import AvailabilityResponse
 from hdx_hapi.endpoints.util.util import (
+    AdminLevel,
     CommonEndpointParams,
     OutputFormat,
     common_endpoint_parameters,
@@ -81,6 +83,7 @@ async def get_data_availability(
         Optional[datetime.datetime | datetime.date],
         Query(description=f'{DOC_UPDATE_DATE_MAX}'),
     ] = None,
+    admin_level: Annotated[Optional[AdminLevel], Query(description=f'{DOC_ADMIN_LEVEL_FILTER}')] = None,
     output_format: OutputFormat = OutputFormat.JSON,
 ):
     """
@@ -99,5 +102,6 @@ async def get_data_availability(
         admin2_code=admin2_code,
         hapi_updated_date_min=hapi_updated_date_min,
         hapi_updated_date_max=hapi_updated_date_max,
+        admin_level=admin_level,
     )
     return transform_result_to_csv_stream_if_requested(result, output_format, AvailabilityResponse)

--- a/hdx_hapi/endpoints/models/availability.py
+++ b/hdx_hapi/endpoints/models/availability.py
@@ -31,11 +31,11 @@ class AvailabilityResponse(HapiBaseModel):
     @model_validator(mode='after')  
     def set_admin1_admin2_null(self) -> Self:
 
-        if self.admin1_name and self.admin1_name.upper() == 'UNSPECIFIED':
+        if not self.admin1_name or self.admin1_name.upper() == 'UNSPECIFIED':
             self.admin1_code = None
             self.admin1_name = None
 
-        if self.admin2_name and self.admin2_name.upper() == 'UNSPECIFIED':
+        if not self.admin2_name or self.admin2_name.upper() == 'UNSPECIFIED':
             self.admin2_code = None
             self.admin2_name = None
 

--- a/hdx_hapi/endpoints/models/availability.py
+++ b/hdx_hapi/endpoints/models/availability.py
@@ -1,6 +1,6 @@
 import datetime
-from typing import Optional
-from pydantic import ConfigDict, Field
+from typing import Optional, Self
+from pydantic import ConfigDict, Field, model_validator
 from hdx_hapi.endpoints.models.base import HapiBaseModel
 from hdx_hapi.config.doc_snippets import (
     truncate_query_description,
@@ -27,3 +27,16 @@ class AvailabilityResponse(HapiBaseModel):
     )
 
     model_config = ConfigDict(from_attributes=True)
+
+    @model_validator(mode='after')  
+    def set_admin1_admin2_null(self) -> Self:
+
+        if self.admin1_name and self.admin1_name.upper() == 'UNSPECIFIED':
+            self.admin1_code = None
+            self.admin1_name = None
+
+        if self.admin2_name and self.admin2_name.upper() == 'UNSPECIFIED':
+            self.admin2_code = None
+            self.admin2_name = None
+
+        return self

--- a/hdx_hapi/services/admin_level_logic.py
+++ b/hdx_hapi/services/admin_level_logic.py
@@ -1,8 +1,8 @@
-from typing import Optional
+from typing import Tuple, Optional
 from hdx_hapi.endpoints.util.util import AdminLevel
 
 
-def compute_unspecified_values(admin_level: Optional[AdminLevel]):
+def compute_unspecified_values(admin_level: Optional[AdminLevel]) -> Tuple[Optional[bool], Optional[bool]]:
     """
     Compute unspecified values for admin1 and admin2
     """

--- a/hdx_hapi/services/availability_logic.py
+++ b/hdx_hapi/services/availability_logic.py
@@ -1,9 +1,13 @@
 import datetime
-from typing import Optional
+from typing import Optional, Sequence, Union
 from sqlalchemy.ext.asyncio import AsyncSession
 
+
+from hapi_schema.db_views_as_tables import DBAvailabilityVAT
+
 from hdx_hapi.db.dao.availability_view_dao import availability_view_list
-from hdx_hapi.endpoints.util.util import PaginationParams
+from hdx_hapi.db.models.views.all_views import AvailabilityView
+from hdx_hapi.endpoints.util.util import AdminLevel, PaginationParams
 
 
 async def get_availability_srv(
@@ -19,7 +23,9 @@ async def get_availability_srv(
     admin2_code: Optional[str] = None,
     hapi_updated_date_min: Optional[datetime.datetime | datetime.date] = None,
     hapi_updated_date_max: Optional[datetime.datetime | datetime.date] = None,
-):
+    admin_level: Optional[AdminLevel] = None,
+) -> Union[Sequence[AvailabilityView], Sequence[DBAvailabilityVAT]]:
+    
     return await availability_view_list(
         pagination_parameters=pagination_parameters,
         db=db,
@@ -33,4 +39,5 @@ async def get_availability_srv(
         admin2_code=admin2_code,
         hapi_updated_date_min=hapi_updated_date_min,
         hapi_updated_date_max=hapi_updated_date_max,
+        admin_level=admin_level,
     )

--- a/hdx_hapi/services/idps_logic.py
+++ b/hdx_hapi/services/idps_logic.py
@@ -1,7 +1,8 @@
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Union
 from sqlalchemy.ext.asyncio import AsyncSession
-from hapi_schema.utils.base import Base
+from hapi_schema.db_views_as_tables import DBIDPsVAT
 from hdx_hapi.db.dao.idps_view_dao import idps_view_list
+from hdx_hapi.db.models.views.all_views import IdpsView
 from hdx_hapi.endpoints.util.util import AdminLevel, PaginationParams, ReferencePeriodParameters
 from hdx_hapi.services.admin_level_logic import compute_unspecified_values
 
@@ -24,7 +25,7 @@ async def get_idps_srv(
     admin2_code: Optional[str] = None,
     admin2_name: Optional[str] = None,
     admin_level: Optional[AdminLevel] = None,
-) -> Sequence[Base]:
+) -> Union[Sequence[IdpsView], Sequence[DBIDPsVAT]]:
     admin1_is_unspecified, admin2_is_unspecified = compute_unspecified_values(admin_level)
     return await idps_view_list(
         pagination_parameters=pagination_parameters,

--- a/tests/test_endpoints/test_data_availability_endpoint.py
+++ b/tests/test_endpoints/test_data_availability_endpoint.py
@@ -3,7 +3,9 @@ import logging
 
 from httpx import AsyncClient
 from main import app
+from hdx_hapi.endpoints.util.util import AdminLevel
 from tests.test_endpoints.endpoint_data import endpoint_data
+
 
 log = logging.getLogger(__name__)
 
@@ -58,3 +60,38 @@ async def test_get_data_availability_result(event_loop, refresh_db):
     assert len(response.json()['data'][0]) == len(
         expected_fields
     ), 'Response has a different number of fields than expected'
+
+
+@pytest.mark.asyncio
+async def test_get_data_availability_for_admin_level_filter(event_loop, refresh_db):
+    log.info('started test_get_data_availability_result')
+
+    async with AsyncClient(app=app, base_url='http://test', params={'admin_level': AdminLevel.ZERO.value,}) as ac:
+        response = await ac.get(ENDPOINT_ROUTER)
+        results = response.json()['data']
+        assert len(results) > 0
+        for item in results:
+            assert item['admin1_code'] is None
+            assert item['admin2_code'] is None
+            assert item['admin1_name'] is None
+            assert item['admin2_name'] is None
+
+    async with AsyncClient(app=app, base_url='http://test', params={'admin_level': AdminLevel.ONE.value,}) as ac:
+        response = await ac.get(ENDPOINT_ROUTER)
+        results = response.json()['data']
+        assert len(results) > 0
+        for item in results:
+            assert item['admin2_code'] is None
+            assert item['admin2_name'] is None
+            assert item['admin1_code'] is not None
+            assert item['admin1_name'] is not None
+    
+    async with AsyncClient(app=app, base_url='http://test', params={'admin_level': AdminLevel.TWO.value,}) as ac:
+        response = await ac.get(ENDPOINT_ROUTER)
+        results = response.json()['data']
+        assert len(results) > 0
+        for item in results:
+            assert item['admin2_code'] is not None
+            assert item['admin2_name'] is not None
+            assert item['admin1_code'] is not None
+            assert item['admin1_name'] is not None


### PR DESCRIPTION
- not showing UNSPECIFIED for adminX names in the data availability endpoints anymore. Instead changed to null/None as it happens for the other endpoints.
- adminX codes are also turned to null
- adding admin level filter
