### PR TITLE
Only send Mixpanel events for nginx-verified requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/unocha/python:3.12-stable
+FROM public.ecr.aws/unocha/python:3.14-stable
 
 WORKDIR /srv/hapi
 

--- a/docker/unit-elastic.json.tpl
+++ b/docker/unit-elastic.json.tpl
@@ -6,7 +6,7 @@
     },
     "applications": {
         "hapi": {
-            "type": "python 3.12",
+            "type": "python 3.14",
             "threads": 1,
             "processes": {
                 "max": ${UNITD_MAX_WORKERS},

--- a/docker/unit.json.tpl
+++ b/docker/unit.json.tpl
@@ -6,7 +6,7 @@
     },
     "applications": {
         "hapi": {
-            "type": "python 3.12",
+            "type": "python 3.14",
             "threads": 1,
             "processes": {
                 "max": ${UNITD_MAX_WORKERS},

--- a/hdx_hapi/endpoints/middleware/util/util.py
+++ b/hdx_hapi/endpoints/middleware/util/util.py
@@ -17,10 +17,10 @@ _CONFIG = get_config()
 async def track_api_call(request: Request, response: Response):
     is_nginx_verify_request = getattr(request.state, 'is_nginx_verify_request', False)
 
-    if is_nginx_verify_request:
-        endpoint, query_params_keys, output_format, admin_level, current_url = _parse_nginx_header(request)
-    else:
-        endpoint, query_params_keys, output_format, admin_level, current_url = _parse_fastapi_request(request)
+    if not is_nginx_verify_request:
+        return
+
+    endpoint, query_params_keys, output_format, admin_level, current_url = _parse_nginx_header(request)
 
     app_name = getattr(request.state, 'app_name', None)
     user_agent_string = request.headers.get('user-agent', '')
@@ -55,10 +55,10 @@ async def track_api_call(request: Request, response: Response):
 async def track_page_view(request: Request, response: Response):
     is_nginx_verify_request = getattr(request.state, 'is_nginx_verify_request', False)
 
-    if is_nginx_verify_request:
-        _, _, _, _, current_url = _parse_nginx_header(request)
-    else:
-        _, _, _, _, current_url = _parse_fastapi_request(request)
+    if not is_nginx_verify_request:
+        return
+
+    _, _, _, _, current_url = _parse_nginx_header(request)
 
     user_agent_string = request.headers.get('user-agent', '')
     ip_address = request.headers.get('x-forwarded-for', '')
@@ -105,32 +105,34 @@ def extract_path_identifier_and_query_params(original_url: str) -> Tuple[str, Op
     return path, app_identifier, query_params
 
 
-def _parse_fastapi_request(request: Request) -> Tuple[str, List[str], str, str, str]:
-    """
-    Parse the FastAPI request to extract data needed for analytics.
-
-    Args:
-        request: The FastAPI request object
-
-    Returns:
-        Tuple containing endpoint, query_params_keys, output_format, admin_level and current_url
-    """
-    app_identifier = request.query_params.get('app_identifier', '')
-    endpoint = request.url.path
-
-    query_params_keys = list(request.query_params.keys())
-    output_format = request.query_params.get('output_format', '')
-    admin_level = request.query_params.get('admin_level', '')
-    email_address = request.query_params.get('email', '')
-
-    current_url = unquote(str(request.url))
-
-    if app_identifier:
-        current_url = current_url.replace(app_identifier, 'unavailable')
-    if email_address:
-        current_url = current_url.replace(email_address, 'unavailable')
-
-    return endpoint, query_params_keys, output_format, admin_level, current_url
+# Unused now that track_api_call/track_page_view return early for non-nginx-verified requests.
+# Kept as reference for how to parse analytics data directly from a FastAPI request.
+# def _parse_fastapi_request(request: Request) -> Tuple[str, List[str], str, str, str]:
+#     """
+#     Parse the FastAPI request to extract data needed for analytics.
+#
+#     Args:
+#         request: The FastAPI request object
+#
+#     Returns:
+#         Tuple containing endpoint, query_params_keys, output_format, admin_level and current_url
+#     """
+#     app_identifier = request.query_params.get('app_identifier', '')
+#     endpoint = request.url.path
+#
+#     query_params_keys = list(request.query_params.keys())
+#     output_format = request.query_params.get('output_format', '')
+#     admin_level = request.query_params.get('admin_level', '')
+#     email_address = request.query_params.get('email', '')
+#
+#     current_url = unquote(str(request.url))
+#
+#     if app_identifier:
+#         current_url = current_url.replace(app_identifier, 'unavailable')
+#     if email_address:
+#         current_url = current_url.replace(email_address, 'unavailable')
+#
+#     return endpoint, query_params_keys, output_format, admin_level, current_url
 
 
 def _parse_nginx_header(request: Request) -> Tuple[str, List[str], str, str, str]:

--- a/tests/test_analytics/test_api_call_tracking.py
+++ b/tests/test_analytics/test_api_call_tracking.py
@@ -1,5 +1,4 @@
 import logging
-import time
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -14,10 +13,27 @@ TEST_USER_AGENT = (
 log = logging.getLogger(__name__)
 
 ENDPOINT = '/api/v2/coordination-context/operational-presence'
+VERIFY_REQUEST_ENDPOINT = '/api/v2/util/verify-request'
+ALLOWED_API_ENDPOINT = '/api/v2/util/version'
 
 
 @pytest.mark.asyncio
-async def test_tracking_endpoint_success():
+async def test_direct_api_call_not_tracked():
+    with patch('hdx_hapi.endpoints.middleware.util.util.send_mixpanel_event') as send_mixpanel_event_patch:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=TEST_BASE_URL) as ac:
+            headers = {
+                'User-Agent': TEST_USER_AGENT,
+                'x-forwarded-for': '127.0.0.1',
+            }
+            params = {'admin_level': '1', 'output_format': 'json'}
+            response = await ac.get(ENDPOINT, params=params, headers=headers)
+
+        assert response.status_code == 200
+        assert send_mixpanel_event_patch.call_count == 0, 'Direct (non-nginx-verified) API calls should not be tracked'
+
+
+@pytest.mark.asyncio
+async def test_nginx_verified_api_call_tracked(enable_hapi_identifier_filtering):
     with (
         patch('hdx_hapi.endpoints.middleware.util.util.send_mixpanel_event') as send_mixpanel_event_patch,
         patch(
@@ -29,40 +45,41 @@ async def test_tracking_endpoint_success():
             headers = {
                 'User-Agent': TEST_USER_AGENT,
                 'x-forwarded-for': '127.0.0.1',
+                'X-Original-URI': ALLOWED_API_ENDPOINT,
             }
-            params = {'admin_level': '1', 'output_format': 'json'}
-            response = await ac.get(ENDPOINT, params=params, headers=headers)
+            response = await ac.get(VERIFY_REQUEST_ENDPOINT, headers=headers)
 
         assert response.status_code == 200
-        assert send_mixpanel_event_patch.call_count == 1, 'API calls should be tracked'
+        assert send_mixpanel_event_patch.call_count == 1, 'Nginx-verified API calls should be tracked'
 
-        expected_mixpanel_dict = {
-            'endpoint path': ENDPOINT,
-            'query params': ['admin_level', 'output_format'],
-            'time': pytest.approx(time.time()),
-            'app name': None,
-            'identifier verification': False,
-            'output format': 'json',
-            'admin level': '1',
-            'server side': True,
-            'response code': 200,
-            'user agent': TEST_USER_AGENT,
-            'ip': '127.0.0.1',
-            '$os': 'Windows',
-            '$browser': 'Chrome',
-            '$browser_version': '124',
-            '$current_url': f'{TEST_BASE_URL}{ENDPOINT}?admin_level=1&output_format=json',
-        }
-
-        # Check parameters match the expected ones
-        send_mixpanel_event_patch.assert_called_once_with('hapi api call', '123456', expected_mixpanel_dict)
+        event_name, distinct_id, event_data = send_mixpanel_event_patch.call_args.args
+        assert event_name == 'hapi api call'
+        assert distinct_id == '123456'
+        assert event_data['identifier verification'] is True
+        assert event_data['endpoint path'] == ALLOWED_API_ENDPOINT
+        assert event_data['response code'] == 200
 
 
 @pytest.mark.asyncio
-async def test_docs_page_tracked():
+async def test_direct_docs_page_not_tracked():
     with patch('hdx_hapi.endpoints.middleware.util.util.send_mixpanel_event') as send_mixpanel_event_patch:
         async with AsyncClient(transport=ASGITransport(app=app), base_url=TEST_BASE_URL) as ac:
             response = await ac.get('/docs')
 
         assert response.status_code == 200
-        assert send_mixpanel_event_patch.call_count == 1, 'Docs page should be tracked as a page view'
+        assert send_mixpanel_event_patch.call_count == 0, 'Direct (non-nginx-verified) docs view should not be tracked'
+
+
+@pytest.mark.asyncio
+async def test_nginx_verified_docs_page_tracked(enable_hapi_identifier_filtering):
+    with patch('hdx_hapi.endpoints.middleware.util.util.send_mixpanel_event') as send_mixpanel_event_patch:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=TEST_BASE_URL) as ac:
+            headers = {'X-Original-URI': '/docs'}
+            response = await ac.get(VERIFY_REQUEST_ENDPOINT, headers=headers)
+
+        assert response.status_code == 200
+        assert send_mixpanel_event_patch.call_count == 1, 'Nginx-verified docs page view should be tracked'
+
+        event_name, _, event_data = send_mixpanel_event_patch.call_args.args
+        assert event_name == 'hapi openapi docs view'
+        assert event_data['identifier verification'] is True


### PR DESCRIPTION
Gate track_api_call/track_page_view on is_nginx_verify_request so direct requests (bypassing nginx's verify-request subrequest) are no longer tracked. Updated tests to cover both the skipped and tracked cases.